### PR TITLE
Automatically promote Sonatype releases

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -23,4 +23,4 @@ jobs:
           java-version: 11
 
       - name: Publish plugin to Sonatype
-        run: ./gradlew publish -PwithoutSample --no-daemon --stacktrace
+        run: ./gradlew publish closeAndReleaseSonatypeStagingRepository -PwithoutSample --no-daemon --stacktrace

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,8 +1,10 @@
+import io.github.gradlenexus.publishplugin.NexusPublishExtension
+
 buildscript {
     repositories {
         mavenLocal {
             content {
-                includeGroup("com.spotify.ruler") // Only load Ruler plugin from local Maven, for the sample project
+                includeGroup(RULER_PLUGIN_GROUP) // Only load Ruler plugin from local Maven, for the sample project
             }
         }
         google()
@@ -15,6 +17,7 @@ buildscript {
         classpath(Dependencies.KOTLINX_SERIALIZATION_GRADLE_PLUGIN)
         classpath(Dependencies.KOTLIN_REACT_FUNCTION_GRADLE_PLUGIN)
         classpath(Dependencies.DETEKT_GRADLE_PLUGIN)
+        classpath(Dependencies.NEXUS_PUBLISH_GRADLE_PLUGIN)
 
         if (!properties.containsKey("withoutSample")) {
             classpath(Dependencies.RULER_GRADLE_PLUGIN)
@@ -22,9 +25,23 @@ buildscript {
     }
 }
 
+apply(plugin = "io.github.gradle-nexus.publish-plugin")
+
 allprojects {
     repositories {
         google()
         mavenCentral()
+    }
+}
+
+group = RULER_PLUGIN_GROUP
+version = RULER_PLUGIN_VERSION
+
+extensions.configure(NexusPublishExtension::class) {
+    repositories {
+        sonatype {
+            username.set(System.getenv(ENV_SONATYPE_USERNAME))
+            password.set(System.getenv(ENV_SONATYPE_PASSWORD))
+        }
     }
 }

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -15,13 +15,14 @@
  */
 
 object Dependencies {
-    const val RULER_GRADLE_PLUGIN = "com.spotify.ruler:ruler-gradle-plugin:$RULER_PLUGIN_VERSION"
+    const val RULER_GRADLE_PLUGIN = "$RULER_PLUGIN_GROUP:ruler-gradle-plugin:$RULER_PLUGIN_VERSION"
 
     const val ANDROID_GRADLE_PLUGIN = "com.android.tools.build:gradle:${Versions.ANDROID_GRADLE_PLUGIN}"
     const val KOTLIN_GRADLE_PLUGIN = "org.jetbrains.kotlin:kotlin-gradle-plugin:${Versions.KOTLIN}"
     const val KOTLINX_SERIALIZATION_GRADLE_PLUGIN = "org.jetbrains.kotlin:kotlin-serialization:${Versions.KOTLIN}"
     const val KOTLIN_REACT_FUNCTION_GRADLE_PLUGIN = "gradle.plugin.com.bnorm.react:kotlin-react-function-gradle:${Versions.KOTLIN_REACT_FUNCTION}"
     const val DETEKT_GRADLE_PLUGIN = "io.gitlab.arturbosch.detekt:detekt-gradle-plugin:${Versions.DETEKT_GRADLE_PLUGIN}"
+    const val NEXUS_PUBLISH_GRADLE_PLUGIN = "io.github.gradle-nexus.publish-plugin:io.github.gradle-nexus.publish-plugin.gradle.plugin:${Versions.NEXUS_PUBLISH_GRADLE_PLUGIN}"
 
     const val APK_ANALYZER = "com.android.tools.apkparser:apkanalyzer:${Versions.APK_ANALYZER}"
     const val KOTLINX_SERIALIZATION_CORE = "org.jetbrains.kotlinx:kotlinx-serialization-core:${Versions.KOTLINX_SERIALIZATION}"
@@ -47,6 +48,7 @@ object Dependencies {
         const val KOTLIN = "1.5.21" // https://mvnrepository.com/artifact/org.jetbrains.kotlin/kotlin-stdlib
         const val KOTLIN_REACT_FUNCTION = "0.5.1" // https://mvnrepository.com/artifact/com.bnorm.react.kotlin-react-function/com.bnorm.react.kotlin-react-function.gradle.plugin
         const val DETEKT_GRADLE_PLUGIN = "1.17.1" // https://mvnrepository.com/artifact/io.gitlab.arturbosch.detekt/detekt-gradle-plugin
+        const val NEXUS_PUBLISH_GRADLE_PLUGIN = "1.1.0" // https://mvnrepository.com/artifact/io.github.gradle-nexus.publish-plugin/io.github.gradle-nexus.publish-plugin.gradle.plugin
 
         const val APK_ANALYZER = "27.2.2" // https://mvnrepository.com/artifact/com.android.tools.apkparser/apkanalyzer
         const val KOTLINX_SERIALIZATION = "1.2.2" // https://mvnrepository.com/artifact/org.jetbrains.kotlinx/kotlinx-serialization-core

--- a/buildSrc/src/main/kotlin/Publish.kt
+++ b/buildSrc/src/main/kotlin/Publish.kt
@@ -23,6 +23,7 @@ import org.gradle.kotlin.dsl.extra
 import org.gradle.plugins.signing.SigningExtension
 import java.net.URI
 
+const val RULER_PLUGIN_GROUP = "com.spotify.ruler"
 const val RULER_PLUGIN_VERSION = "0.1.0" // Also adapt this version in the README
 
 const val EXT_POM_NAME = "POM_NAME"
@@ -39,18 +40,8 @@ fun PublishingExtension.configurePublications(project: Project) {
         archiveClassifier.set("javadoc") // Use empty javadoc JAR until Dokka supports Kotlin Multiplatform projects
     }
 
-    repositories {
-        maven {
-            name = "sonatype"
-            url = URI.create("https://oss.sonatype.org/service/local/staging/deploy/maven2/")
-            credentials {
-                username = System.getenv(ENV_SONATYPE_USERNAME)
-                password = System.getenv(ENV_SONATYPE_PASSWORD)
-            }
-        }
-    }
     publications.withType(MavenPublication::class.java) {
-        groupId = "com.spotify.ruler"
+        groupId = RULER_PLUGIN_GROUP
         version = RULER_PLUGIN_VERSION
 
         artifact(javadocJar)


### PR DESCRIPTION
### What has changed
<!-- A concise description of the changes contained in this pull request. -->
Sonatype releases are now automatically promoted and released.

### Why was it changed
<!-- A concise description of why these changes are being proposed. -->
Up until now, releasing would require us to manually go into Sonatype and promote the version. This change automates this step, so that the only thing we need to do to release a new version is create a release on GitHub.

### Related issues
<!-- Links to any related issues, if there are some. -->
N/A
