### PR TITLE
Upgrade Android Gradle Plugin to 7.0.0

### DIFF
--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -24,7 +24,13 @@ object Dependencies {
     const val DETEKT_GRADLE_PLUGIN = "io.gitlab.arturbosch.detekt:detekt-gradle-plugin:${Versions.DETEKT_GRADLE_PLUGIN}"
     const val NEXUS_PUBLISH_GRADLE_PLUGIN = "io.github.gradle-nexus.publish-plugin:io.github.gradle-nexus.publish-plugin.gradle.plugin:${Versions.NEXUS_PUBLISH_GRADLE_PLUGIN}"
 
-    const val APK_ANALYZER = "com.android.tools.apkparser:apkanalyzer:${Versions.APK_ANALYZER}"
+    const val BUNDLETOOL = "com.android.tools.build:bundletool:${Versions.BUNDLETOOL}"
+    const val PROTOBUF_CORE = "com.google.protobuf:protobuf-java:${Versions.PROTOBUF}"
+    const val DEXLIB = "org.smali:dexlib2:${Versions.DEXLIB}"
+    const val ANDROID_TOOLS_COMMON = "com.android.tools:common:${Versions.ANDROID_TOOLS}"
+    const val ANDROID_TOOLS_SDKLIB = "com.android.tools:sdklib:${Versions.ANDROID_TOOLS}"
+
+    const val APK_ANALYZER = "com.android.tools.apkparser:apkanalyzer:${Versions.ANDROID_TOOLS}"
     const val KOTLINX_SERIALIZATION_CORE = "org.jetbrains.kotlinx:kotlinx-serialization-core:${Versions.KOTLINX_SERIALIZATION}"
     const val KOTLINX_SERIALIZATION_JSON = "org.jetbrains.kotlinx:kotlinx-serialization-json:${Versions.KOTLINX_SERIALIZATION}"
 
@@ -44,13 +50,17 @@ object Dependencies {
     const val BOOTSTRAP = "bootstrap"
 
     object Versions {
-        const val ANDROID_GRADLE_PLUGIN = "4.2.2" // https://mvnrepository.com/artifact/com.android.tools.build/gradle?repo=google
+        const val ANDROID_GRADLE_PLUGIN = "7.0.0" // https://mvnrepository.com/artifact/com.android.tools.build/gradle?repo=google
         const val KOTLIN = "1.5.21" // https://mvnrepository.com/artifact/org.jetbrains.kotlin/kotlin-stdlib
         const val KOTLIN_REACT_FUNCTION = "0.5.1" // https://mvnrepository.com/artifact/com.bnorm.react.kotlin-react-function/com.bnorm.react.kotlin-react-function.gradle.plugin
         const val DETEKT_GRADLE_PLUGIN = "1.17.1" // https://mvnrepository.com/artifact/io.gitlab.arturbosch.detekt/detekt-gradle-plugin
         const val NEXUS_PUBLISH_GRADLE_PLUGIN = "1.1.0" // https://mvnrepository.com/artifact/io.github.gradle-nexus.publish-plugin/io.github.gradle-nexus.publish-plugin.gradle.plugin
 
-        const val APK_ANALYZER = "27.2.2" // https://mvnrepository.com/artifact/com.android.tools.apkparser/apkanalyzer
+        const val BUNDLETOOL = "1.7.0" // https://mvnrepository.com/artifact/com.android.tools.build/bundletool
+        const val PROTOBUF = "3.17.3" // https://mvnrepository.com/artifact/com.google.protobuf/protobuf-java
+        const val DEXLIB = "2.5.2" // https://mvnrepository.com/artifact/org.smali/dexlib2
+
+        const val ANDROID_TOOLS = "30.0.0" // https://mvnrepository.com/artifact/com.android.tools/common?repo=google
         const val KOTLINX_SERIALIZATION = "1.2.2" // https://mvnrepository.com/artifact/org.jetbrains.kotlinx/kotlinx-serialization-core
 
         const val JUNIT = "5.7.2" // https://mvnrepository.com/artifact/org.junit.jupiter/junit-jupiter-engine

--- a/ruler-gradle-plugin/build.gradle.kts
+++ b/ruler-gradle-plugin/build.gradle.kts
@@ -12,6 +12,11 @@ extra[EXT_POM_DESCRIPTION] = "Gradle plugin for analyzing Android app size"
 dependencies {
     compileOnly(gradleApi())
     compileOnly(Dependencies.ANDROID_GRADLE_PLUGIN)
+    compileOnly(Dependencies.BUNDLETOOL)
+    compileOnly(Dependencies.PROTOBUF_CORE)
+    compileOnly(Dependencies.ANDROID_TOOLS_COMMON)
+    compileOnly(Dependencies.ANDROID_TOOLS_SDKLIB)
+    compileOnly(Dependencies.DEXLIB)
 
     implementation(project(":ruler-models"))
 

--- a/ruler-gradle-plugin/src/main/kotlin/com/spotify/ruler/plugin/RulerPlugin.kt
+++ b/ruler-gradle-plugin/src/main/kotlin/com/spotify/ruler/plugin/RulerPlugin.kt
@@ -16,8 +16,8 @@
 
 package com.spotify.ruler.plugin
 
-import com.android.build.api.artifact.ArtifactType
-import com.android.build.api.extension.ApplicationAndroidComponentsExtension
+import com.android.build.api.artifact.SingleArtifact
+import com.android.build.api.variant.ApplicationAndroidComponentsExtension
 import com.android.build.api.variant.ApplicationVariant
 import com.spotify.ruler.plugin.models.AppInfo
 import com.spotify.ruler.plugin.models.DeviceSpec
@@ -39,8 +39,8 @@ class RulerPlugin : Plugin<Project> {
                     task.appInfo.set(getAppInfo(project, variant))
                     task.deviceSpec.set(getDeviceSpec(project, rulerExtension))
 
-                    task.bundleFile.set(variant.artifacts.get(ArtifactType.BUNDLE))
-                    task.mappingFile.set(variant.artifacts.get(ArtifactType.OBFUSCATION_MAPPING_FILE))
+                    task.bundleFile.set(variant.artifacts.get(SingleArtifact.BUNDLE))
+                    task.mappingFile.set(variant.artifacts.get(SingleArtifact.OBFUSCATION_MAPPING_FILE))
 
                     task.workingDir.set(project.layout.buildDirectory.dir("intermediates/ruler/${variant.name}"))
                     task.reportDir.set(project.layout.buildDirectory.dir("reports/ruler/${variant.name}"))

--- a/ruler-gradle-plugin/src/test/resources/project-fixture/app/build.gradle
+++ b/ruler-gradle-plugin/src/test/resources/project-fixture/app/build.gradle
@@ -4,17 +4,17 @@ plugins {
 }
 
 android {
-    compileSdkVersion(31)
+    compileSdk = 31
     defaultConfig {
         applicationId = "com.spotify.ruler.test"
-        minSdkVersion(23)
-        targetSdkVersion(31)
-        versionCode(1)
-        versionName("1.0")
+        minSdk = 23
+        targetSdk = 31
+        versionCode = 1
+        versionName = "1.0"
     }
     buildTypes {
         release {
-            minifyEnabled(true)
+            minifyEnabled = true
             proguardFiles(getDefaultProguardFile("proguard-android-optimize.txt"))
         }
     }

--- a/sample/app/build.gradle.kts
+++ b/sample/app/build.gradle.kts
@@ -4,21 +4,21 @@ plugins {
 }
 
 android {
-    compileSdkVersion(31)
+    compileSdk = 31
     defaultConfig {
         applicationId = "com.spotify.ruler.sample"
-        minSdkVersion(23)
-        targetSdkVersion(31)
-        versionCode(1)
-        versionName("1.0")
+        minSdk = 23
+        targetSdk = 31
+        versionCode = 1
+        versionName = "1.0"
     }
     buildTypes {
-        named("release").configure {
-            minifyEnabled(true)
+        release {
+            isMinifyEnabled = true
             proguardFiles(getDefaultProguardFile("proguard-android-optimize.txt"))
         }
     }
-    lintOptions {
+    lint {
         isWarningsAsErrors = true
     }
 }

--- a/sample/lib/build.gradle.kts
+++ b/sample/lib/build.gradle.kts
@@ -3,12 +3,12 @@ plugins {
 }
 
 android {
-    compileSdkVersion(31)
+    compileSdk = 31
     defaultConfig {
-        minSdkVersion(23)
-        targetSdkVersion(31)
+        minSdk = 23
+        targetSdk = 31
     }
-    lintOptions {
+    lint {
         isWarningsAsErrors = true
     }
 }


### PR DESCRIPTION
### What has changed
<!-- A concise description of the changes contained in this pull request. -->
Android Gradle Plugin version was upgraded from `4.2.2` to `7.0.0`.

### Why was it changed
<!-- A concise description of why these changes are being proposed. -->
We want to stay compatible with the latest stable version of the Android Gradle Plugin.

### Related issues
<!-- Links to any related issues, if there are some. -->
N/A
