### PR TITLE
Publish Gradle build scans for every CI build

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -8,3 +8,19 @@ if (!startParameter.projectProperties.containsKey("withoutSample")) {
     include(":sample:app")
     include(":sample:lib")
 }
+
+plugins {
+    id("com.gradle.enterprise") version "3.6.3"
+}
+
+gradleEnterprise {
+    val isCiBuild = System.getenv("CI").toBoolean()
+
+    buildScan {
+        termsOfServiceUrl = "https://gradle.com/terms-of-service"
+        if (isCiBuild) {
+            termsOfServiceAgree = "yes"
+            publishAlways()
+        }
+    }
+}


### PR DESCRIPTION
### What has changed
<!-- A concise description of the changes contained in this pull request. -->
Every CI build now publishes a Gradle build scan.

### Why was it changed
<!-- A concise description of why these changes are being proposed. -->
To be able to debug and fix build issues on CI easier.

### Related issues
<!-- Links to any related issues, if there are some. -->
N/A
