### PR TITLE
Bumps version of ruler plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ buildscript {
         }
     }
     dependencies {
-        classpath("com.spotify.ruler:ruler-gradle-plugin:0.1.0")
+        classpath("com.spotify.ruler:ruler-gradle-plugin:0.2.0")
     }
 }
 ```

--- a/buildSrc/src/main/kotlin/Publish.kt
+++ b/buildSrc/src/main/kotlin/Publish.kt
@@ -24,7 +24,7 @@ import org.gradle.plugins.signing.SigningExtension
 import java.net.URI
 
 const val RULER_PLUGIN_GROUP = "com.spotify.ruler"
-const val RULER_PLUGIN_VERSION = "0.1.0" // Also adapt this version in the README
+const val RULER_PLUGIN_VERSION = "0.2.0" // Also adapt this version in the README
 
 const val EXT_POM_NAME = "POM_NAME"
 const val EXT_POM_DESCRIPTION = "POM_DESCRIPTION"


### PR DESCRIPTION
### What has changed
Bumps version of ruler plugin


### Why was it changed
Because compatibility with AGP 7.0.0 was merged but the version was not bumped


### Related issues
No related issues
<!-- Links to any related issues, if there are some. -->

