### PR TITLE
Use webpack to load frontend report data

### DIFF
--- a/buildSrc/src/main/kotlin/Webpack.kt
+++ b/buildSrc/src/main/kotlin/Webpack.kt
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2021 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import org.codehaus.groovy.runtime.StringGroovyMethods
+import org.gradle.api.Project
+import org.gradle.api.tasks.Copy
+import org.gradle.kotlin.dsl.register
+
+/**
+ * Makes a directory available to webpack, so its contents can be loaded and used in the frontend. This is done by
+ * copying all files contained in the directory to a folder accessible by webpack, before the webpack task runs.
+ *
+ * @param sourceDirectory The contents of this directory will be made available to webpack.
+ * @param webpackMode Webpack configuration, for which the directory is registered (development or production).
+ */
+fun Project.registerWebpackDirectory(sourceDirectory: String, webpackMode: String) {
+    val mode = StringGroovyMethods.capitalize(webpackMode)
+    val targetDirectory = "js/packages/${rootProject.name}-${project.name}/kotlin"
+
+    val task = tasks.register<Copy>("prepare${mode}WebpackData") {
+        from(layout.projectDirectory.dir(sourceDirectory))
+        into(rootProject.layout.buildDirectory.dir(targetDirectory))
+    }
+
+    // Make sure data is copied before webpack runs
+    tasks.named("browser${mode}Webpack").configure { dependsOn(task) }
+    tasks.named("browser${mode}Run").configure { dependsOn(task) }
+}

--- a/ruler-frontend/build.gradle.kts
+++ b/ruler-frontend/build.gradle.kts
@@ -30,3 +30,7 @@ dependencies {
 
     testImplementation(kotlin("test-js"))
 }
+
+// Make report data directories available to webpack
+registerWebpackDirectory("src/development", "development")
+registerWebpackDirectory("src/production", "production")

--- a/ruler-frontend/src/development/report.json
+++ b/ruler-frontend/src/development/report.json
@@ -1,0 +1,41 @@
+{
+  "name": "com.spotify.music",
+  "version": "1.2.3",
+  "variant": "release",
+  "downloadSize": 750,
+  "installSize": 1050,
+  "components": [
+    {
+      "name": ":lib",
+      "downloadSize": 500,
+      "installSize": 600,
+      "files": [
+        {
+          "name": "/assets/license.html",
+          "type": "ASSET",
+          "downloadSize": 500,
+          "installSize": 600
+        }
+      ]
+    },
+    {
+      "name": ":app",
+      "downloadSize": 250,
+      "installSize": 450,
+      "files": [
+        {
+          "name": "/res/layout/activity_main.xml",
+          "type": "RESOURCE",
+          "downloadSize": 150,
+          "installSize": 250
+        },
+        {
+          "name": "com.spotify.MainActivity",
+          "type": "CLASS",
+          "downloadSize": 100,
+          "installSize": 200
+        }
+      ]
+    }
+  ]
+}

--- a/ruler-frontend/src/main/kotlin/com.spotify.ruler.frontend/Main.kt
+++ b/ruler-frontend/src/main/kotlin/com.spotify.ruler.frontend/Main.kt
@@ -16,13 +16,9 @@
 
 package com.spotify.ruler.frontend
 
-import com.spotify.ruler.models.AppComponent
-import com.spotify.ruler.models.AppFile
 import com.spotify.ruler.models.AppReport
-import com.spotify.ruler.models.FileType
 import kotlinext.js.require
 import kotlinx.browser.document
-import kotlinx.serialization.SerializationException
 import kotlinx.serialization.decodeFromString
 import kotlinx.serialization.json.Json
 import react.dom.render
@@ -31,32 +27,12 @@ fun main() {
     require("bootstrap/dist/css/bootstrap.css")
     require("bootstrap/dist/js/bootstrap.bundle.js")
 
-    val report = getReportData()
+    // Load and deserialize the report data
+    val rawReport = require("./report.json").toString()
+    val report = Json.decodeFromString<AppReport>(rawReport)
+
+    // Visualize and display the report data
     render(document.getElementById("root")) {
         reportCard(report)
     }
 }
-
-fun getReportData(): AppReport = try {
-    getRealReportData() // Try to read real data
-} catch (ignored: SerializationException) {
-    getFakeReportData() // If not real data is provided, fall back to fake data
-}
-
-// Provides the real report data, for the generated report
-fun getRealReportData(): AppReport {
-    val json = "REPLACE_ME" // Will be replaced with the report data in JSON format
-    return Json.decodeFromString(json)
-}
-
-// Provides fake report data, to be able to work on the frontend independently
-@Suppress("MagicNumber")
-fun getFakeReportData(): AppReport = AppReport("com.spotify.music", "1.2.3", "release", 750, 1050, listOf(
-    AppComponent(":lib", 500, 600, listOf(
-        AppFile("/assets/license.html", FileType.ASSET, 500, 600),
-    )),
-    AppComponent(":app", 250, 450, listOf(
-        AppFile("/res/layout/activity_main.xml", FileType.RESOURCE, 150, 250),
-        AppFile("com.spotify.MainActivity", FileType.CLASS, 100, 200),
-    )),
-))

--- a/ruler-frontend/src/production/report.json
+++ b/ruler-frontend/src/production/report.json
@@ -1,0 +1,1 @@
+REPLACE_ME

--- a/ruler-frontend/webpack.config.d/config.js
+++ b/ruler-frontend/webpack.config.d/config.js
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2021 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Load raw JSON files instead of trying to parse them
+config.module.rules.push({
+    test: /\.json$/,
+    type: 'asset/source',
+});


### PR DESCRIPTION
### What has changed
<!-- A concise description of the changes contained in this pull request. -->
- Frontend report data is now loaded via webpack.

### Why was it changed
<!-- A concise description of why these changes are being proposed. -->
- In the previous setup, data only intended for development purposes would end up leaking into the generated reports, making reports bigger than they need to be.
- The new setup also uses the same JSON parsing logic for development data, making it easier to verify and to iterate on.

### Related issues
<!-- Links to any related issues, if there are some. -->
N/A
