### PR TITLE
Fix nullability warnings in HtmlReporter

### DIFF
--- a/ruler-gradle-plugin/src/main/kotlin/com/spotify/ruler/plugin/report/HtmlReporter.kt
+++ b/ruler-gradle-plugin/src/main/kotlin/com/spotify/ruler/plugin/report/HtmlReporter.kt
@@ -29,10 +29,10 @@ class HtmlReporter {
      * @return Generated HTML report file
      */
     fun generateReport(json: String, targetDir: File): File {
-        var html = javaClass.getResource("/index.html").readText()
+        var html = readResourceFile("index.html")
 
         // Inline Javascript
-        val javascript = javaClass.getResource("/ruler-frontend.js").readText()
+        val javascript = readResourceFile("ruler-frontend.js")
         html = html.replaceFirst("<script src=\"ruler-frontend.js\"></script>", "<script>$javascript</script>")
 
         // Inline JSON data
@@ -41,5 +41,10 @@ class HtmlReporter {
         val reportFile = targetDir.resolve("report.html")
         reportFile.writeText(html)
         return reportFile
+    }
+
+    private fun readResourceFile(fileName: String): String {
+        val url = requireNotNull(javaClass.getResource("/$fileName"))
+        return url.readText()
     }
 }


### PR DESCRIPTION
### What has changed
<!-- A concise description of the changes contained in this pull request. -->
Nullability warnings in `HtmlReporter` are now fixed

### Why was it changed
<!-- A concise description of why these changes are being proposed. -->
Because we shouldn't have warnings and be explicit about nullability 🤷‍♂️ 

### Related issues
<!-- Links to any related issues, if there are some. -->
N/A
