### PR TITLE
Include Ruler tasks in sample app checks

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -36,3 +36,10 @@ jobs:
 
       - name: Run checks
         run: ./gradlew check --no-daemon --stacktrace
+
+      - name: Archive sample HTML report
+        uses: actions/upload-artifact@v2
+        with:
+          name: report
+          path: sample/app/build/reports/ruler/release/report.html
+          retention-days: 7

--- a/sample/app/build.gradle.kts
+++ b/sample/app/build.gradle.kts
@@ -33,3 +33,9 @@ ruler {
     screenDensity.set(480)
     sdkVersion.set(27)
 }
+
+// Include Ruler tasks in checks
+tasks.named("check").configure {
+    dependsOn("analyzeDebugBundle")
+    dependsOn("analyzeReleaseBundle")
+}


### PR DESCRIPTION
### What has changed
<!-- A concise description of the changes contained in this pull request. -->
Ruler tasks in the sample app are now run as part of the `check` Gradle task.

### Why was it changed
<!-- A concise description of why these changes are being proposed. -->
To verify the plugin integration into the sample works correctly.

### Related issues
<!-- Links to any related issues, if there are some. -->
N/A
