### PR TITLE
Fix HTML report card background color

### DIFF
--- a/ruler-frontend/src/main/kotlin/com.spotify.ruler.frontend/Components.kt
+++ b/ruler-frontend/src/main/kotlin/com.spotify.ruler.frontend/Components.kt
@@ -42,7 +42,7 @@ import react.useState
 @RFunction
 fun RBuilder.reportCard(report: AppReport) {
     div(classes = "container mt-4 mb-4") {
-        div(classes = "shadow-sm p-4 mb-5 bg-body rounded-1") {
+        div(classes = "shadow-sm p-4 mb-5 bg-white rounded-1") {
             reportHeader(report)
             hr {}
             componentBreakdown(report.components)


### PR DESCRIPTION
### What has changed
<!-- A concise description of the changes contained in this pull request. -->
Background color of the HTML report card was fixed.

### Why was it changed
<!-- A concise description of why these changes are being proposed. -->
Background color (`bg-body`) changed due to the latest Bootstrap upgrade, making the report unreadable.

### Related issues
<!-- Links to any related issues, if there are some. -->
N/A

### Before
<img width="1301" alt="Screenshot 2021-08-14 at 17 54 24" src="https://user-images.githubusercontent.com/23724790/129452074-01f6a119-231a-4ff5-95f6-386876c1943f.png">

### After
<img width="1301" alt="Screenshot 2021-08-14 at 17 56 12" src="https://user-images.githubusercontent.com/23724790/129452079-f21eeb97-d2e6-4b78-ab16-1d68bc7d5ded.png">

