### PR TITLE
Differentiate between internal and external components

### DIFF
--- a/ruler-gradle-plugin/src/main/kotlin/com/spotify/ruler/plugin/RulerTask.kt
+++ b/ruler-gradle-plugin/src/main/kotlin/com/spotify/ruler/plugin/RulerTask.kt
@@ -17,11 +17,13 @@
 package com.spotify.ruler.plugin
 
 import com.spotify.ruler.models.AppFile
+import com.spotify.ruler.models.ComponentType
 import com.spotify.ruler.plugin.apk.ApkCreator
 import com.spotify.ruler.plugin.apk.ApkParser
 import com.spotify.ruler.plugin.apk.ApkSanitizer
 import com.spotify.ruler.plugin.attribution.Attributor
 import com.spotify.ruler.plugin.common.ClassNameSanitizer
+import com.spotify.ruler.plugin.dependency.DependencyComponent
 import com.spotify.ruler.plugin.dependency.DependencyParser
 import com.spotify.ruler.plugin.dependency.DependencySanitizer
 import com.spotify.ruler.plugin.models.AppInfo
@@ -65,7 +67,7 @@ abstract class RulerTask : DefaultTask() {
         val dependencies = getDependencies() // Get all entries from all dependencies
 
         // Attribute bundle entries and group into components
-        val attributor = Attributor(project.path)
+        val attributor = Attributor(DependencyComponent(project.path, ComponentType.INTERNAL))
         val components = attributor.attribute(files, dependencies)
 
         generateReports(components)
@@ -84,7 +86,7 @@ abstract class RulerTask : DefaultTask() {
         return apkSanitizer.sanitize(entries)
     }
 
-    private fun getDependencies(): Map<String, List<String>> {
+    private fun getDependencies(): Map<String, List<DependencyComponent>> {
         val dependencyParser = DependencyParser()
         val entries = dependencyParser.parse(project, appInfo.get())
 
@@ -93,7 +95,7 @@ abstract class RulerTask : DefaultTask() {
         return dependencySanitizer.sanitize(entries)
     }
 
-    private fun generateReports(components: Map<String, List<AppFile>>) {
+    private fun generateReports(components: Map<DependencyComponent, List<AppFile>>) {
         val jsonReporter = JsonReporter()
         val jsonReport = jsonReporter.generateReport(appInfo.get(), components, reportDir.asFile.get())
         project.logger.lifecycle("Wrote JSON report to file://${jsonReport.absolutePath}")

--- a/ruler-gradle-plugin/src/main/kotlin/com/spotify/ruler/plugin/dependency/DependencyComponent.kt
+++ b/ruler-gradle-plugin/src/main/kotlin/com/spotify/ruler/plugin/dependency/DependencyComponent.kt
@@ -14,16 +14,12 @@
 * limitations under the License.
 */
 
-package com.spotify.ruler.models
+package com.spotify.ruler.plugin.dependency
 
-import kotlinx.serialization.Serializable
+import com.spotify.ruler.models.ComponentType
 
-/** Single component of an app. Can either be a Gradle module or a dependency. */
-@Serializable
-data class AppComponent(
+/** Component representing a single dependency. */
+data class DependencyComponent(
     val name: String,
     val type: ComponentType,
-    override val downloadSize: Long,
-    override val installSize: Long,
-    val files: List<AppFile>,
-) : Measurable
+)

--- a/ruler-gradle-plugin/src/main/kotlin/com/spotify/ruler/plugin/report/JsonReporter.kt
+++ b/ruler-gradle-plugin/src/main/kotlin/com/spotify/ruler/plugin/report/JsonReporter.kt
@@ -20,6 +20,7 @@ import com.spotify.ruler.models.AppComponent
 import com.spotify.ruler.models.AppFile
 import com.spotify.ruler.models.AppReport
 import com.spotify.ruler.models.Measurable
+import com.spotify.ruler.plugin.dependency.DependencyComponent
 import com.spotify.ruler.plugin.models.AppInfo
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
@@ -37,16 +38,17 @@ class JsonReporter {
      * @param targetDir Directory where the generated report will be located
      * @return Generated JSON report file
      */
-    fun generateReport(appInfo: AppInfo, components: Map<String, List<AppFile>>, targetDir: File): File {
+    fun generateReport(appInfo: AppInfo, components: Map<DependencyComponent, List<AppFile>>, targetDir: File): File {
         val report = AppReport(
             name = appInfo.applicationId,
             version = appInfo.versionName,
             variant = appInfo.variantName,
             downloadSize = components.values.flatten().sumOf(AppFile::downloadSize),
             installSize = components.values.flatten().sumOf(AppFile::installSize),
-            components = components.map { (componentName, files) ->
+            components = components.map { (component, files) ->
                 AppComponent(
-                    name = componentName,
+                    name = component.name,
+                    type = component.type,
                     downloadSize = files.sumOf(AppFile::downloadSize),
                     installSize = files.sumOf(AppFile::installSize),
                     files = files.sortedWith(comparator.reversed())

--- a/ruler-gradle-plugin/src/test/kotlin/com/spotify/ruler/plugin/attribution/AttributorTest.kt
+++ b/ruler-gradle-plugin/src/test/kotlin/com/spotify/ruler/plugin/attribution/AttributorTest.kt
@@ -18,109 +18,134 @@ package com.spotify.ruler.plugin.attribution
 
 import com.google.common.truth.Truth.assertThat
 import com.spotify.ruler.models.AppFile
+import com.spotify.ruler.models.ComponentType
 import com.spotify.ruler.models.FileType
+import com.spotify.ruler.plugin.dependency.DependencyComponent
 import org.junit.jupiter.api.Test
 
 class AttributorTest {
-    private val attributor = Attributor(":default")
+    private val attributor = Attributor(DependencyComponent(":default", ComponentType.INTERNAL))
 
     @Test
     fun `Class files are attributed correctly`() {
         val files = listOf(AppFile("com.spotify.MainActivity", FileType.CLASS, 100, 200))
-        val dependencies = mapOf("com.spotify.MainActivity" to listOf(":lib"))
+        val dependencies = mapOf("com.spotify.MainActivity" to listOf(
+            DependencyComponent(":lib", ComponentType.INTERNAL),
+        ))
         val map = attributor.attribute(files, dependencies)
 
-        assertThat(map).containsEntry(":lib", files)
+        assertThat(map).containsEntry(DependencyComponent(":lib", ComponentType.INTERNAL), files)
     }
 
     @Test
     fun `Dagger factories are attributed correctly`() {
         val files = listOf(AppFile("com.spotify.TestClass_Factory", FileType.CLASS, 100, 200))
-        val dependencies = mapOf("com.spotify.TestClass" to listOf(":lib"))
+        val dependencies = mapOf("com.spotify.TestClass" to listOf(
+            DependencyComponent(":lib", ComponentType.INTERNAL),
+        ))
         val map = attributor.attribute(files, dependencies)
 
-        assertThat(map).containsEntry(":lib", files)
+        assertThat(map).containsEntry(DependencyComponent(":lib", ComponentType.INTERNAL), files)
     }
 
     @Test
     fun `Dagger modules are attributed correctly`() {
         val files = listOf(AppFile("com.spotify.Module_ProvideModuleFactory", FileType.CLASS, 100, 200))
-        val dependencies = mapOf("com.spotify.Module" to listOf(":lib"))
+        val dependencies = mapOf("com.spotify.Module" to listOf(
+            DependencyComponent(":lib", ComponentType.INTERNAL),
+        ))
         val map = attributor.attribute(files, dependencies)
 
-        assertThat(map).containsEntry(":lib", files)
+        assertThat(map).containsEntry(DependencyComponent(":lib", ComponentType.INTERNAL), files)
     }
 
     @Test
     fun `Lambdas are attributed correctly`() {
         val files = listOf(AppFile("com.spotify.-\$\$Lambda\$sadfjliajsdf", FileType.CLASS, 100, 200))
-        val dependencies = mapOf("com.spotify.MainActivity" to listOf(":lib"))
+        val dependencies = mapOf("com.spotify.MainActivity" to listOf(
+            DependencyComponent(":lib", ComponentType.INTERNAL),
+        ))
         val map = attributor.attribute(files, dependencies)
 
-        assertThat(map).containsEntry(":lib", files)
+        assertThat(map).containsEntry(DependencyComponent(":lib", ComponentType.INTERNAL), files)
     }
 
     @Test
     fun `Classes are attributed based on their package name`() {
         val files = listOf(AppFile("com.spotify.UnknownClass", FileType.CLASS, 100, 200))
-        val dependencies = mapOf("com.spotify.MainActivity" to listOf(":lib"))
+        val dependencies = mapOf("com.spotify.MainActivity" to listOf(
+            DependencyComponent(":lib", ComponentType.INTERNAL),
+        ))
         val map = attributor.attribute(files, dependencies)
 
-        assertThat(map).containsEntry(":lib", files)
+        assertThat(map).containsEntry(DependencyComponent(":lib", ComponentType.INTERNAL), files)
     }
 
     @Test
     fun `Resources are attributed correctly`() {
         val files = listOf(AppFile("/res/layout/activity_main.xml", FileType.RESOURCE, 100, 200))
-        val dependencies = mapOf("/layout/activity_main.xml" to listOf(":lib"))
+        val dependencies = mapOf("/layout/activity_main.xml" to listOf(
+            DependencyComponent(":lib", ComponentType.INTERNAL),
+        ))
         val map = attributor.attribute(files, dependencies)
 
-        assertThat(map).containsEntry(":lib", files)
+        assertThat(map).containsEntry(DependencyComponent(":lib", ComponentType.INTERNAL), files)
     }
 
     @Test
     fun `Assets are attributed correctly`() {
         val files = listOf(AppFile("/assets/licenses.html", FileType.ASSET, 100, 200))
-        val dependencies = mapOf("/licenses.html" to listOf(":lib"))
+        val dependencies = mapOf("/licenses.html" to listOf(
+            DependencyComponent(":lib", ComponentType.INTERNAL),
+        ))
         val map = attributor.attribute(files, dependencies)
 
-        assertThat(map).containsEntry(":lib", files)
+        assertThat(map).containsEntry(DependencyComponent(":lib", ComponentType.INTERNAL), files)
     }
 
     @Test
     fun `Native libs are attributed correctly`() {
         val files = listOf(AppFile("/lib/arm64-v8a/lib.so", FileType.NATIVE_LIB, 100, 200))
-        val dependencies = mapOf("/arm64-v8a/lib.so" to listOf(":lib"))
+        val dependencies = mapOf("/arm64-v8a/lib.so" to listOf(
+            DependencyComponent(":lib", ComponentType.INTERNAL),
+        ))
         val map = attributor.attribute(files, dependencies)
 
-        assertThat(map).containsEntry(":lib", files)
+        assertThat(map).containsEntry(DependencyComponent(":lib", ComponentType.INTERNAL), files)
     }
 
     @Test
     fun `LZMA-compressed native libs are attributed correctly`() {
         val files = listOf(AppFile("/lib/arm64-v8a/lib.lzma.so", FileType.NATIVE_LIB, 100, 200))
-        val dependencies = mapOf("/arm64-v8a/lib.so" to listOf(":lib"))
+        val dependencies = mapOf("/arm64-v8a/lib.so" to listOf(
+            DependencyComponent(":lib", ComponentType.INTERNAL),
+        ))
         val map = attributor.attribute(files, dependencies)
 
-        assertThat(map).containsEntry(":lib", files)
+        assertThat(map).containsEntry(DependencyComponent(":lib", ComponentType.INTERNAL), files)
     }
 
     @Test
     fun `Other files are attributed correctly`() {
         val files = listOf(AppFile("/test.properties", FileType.OTHER, 100, 200))
-        val dependencies = mapOf("/test.properties" to listOf(":lib"))
+        val dependencies = mapOf("/test.properties" to listOf(
+            DependencyComponent(":lib", ComponentType.INTERNAL),
+        ))
         val map = attributor.attribute(files, dependencies)
 
-        assertThat(map).containsEntry(":lib", files)
+        assertThat(map).containsEntry(DependencyComponent(":lib", ComponentType.INTERNAL), files)
     }
 
     @Test
     fun `Files which can be attributed to multiple components belong to the default component`() {
         val files = listOf(AppFile("/test.properties", FileType.OTHER, 100, 200))
-        val dependencies = mapOf("/test.properties" to listOf(":lib", "com.spotify:main:1.0.0"))
+        val dependencies = mapOf("/test.properties" to listOf(
+            DependencyComponent(":lib", ComponentType.INTERNAL),
+            DependencyComponent("com.spotify:main:1.0.0", ComponentType.EXTERNAL),
+        ))
         val map = attributor.attribute(files, dependencies)
 
-        assertThat(map).containsEntry(":default", files)
+        assertThat(map).containsEntry(DependencyComponent(":default", ComponentType.INTERNAL), files)
     }
 
     @Test
@@ -128,6 +153,6 @@ class AttributorTest {
         val files = listOf(AppFile("/test.properties", FileType.OTHER, 100, 200))
         val map = attributor.attribute(files, emptyMap())
 
-        assertThat(map).containsEntry(":default", files)
+        assertThat(map).containsEntry(DependencyComponent(":default", ComponentType.INTERNAL), files)
     }
 }

--- a/ruler-gradle-plugin/src/test/kotlin/com/spotify/ruler/plugin/dependency/DependencySanitizerTest.kt
+++ b/ruler-gradle-plugin/src/test/kotlin/com/spotify/ruler/plugin/dependency/DependencySanitizerTest.kt
@@ -17,6 +17,7 @@
 package com.spotify.ruler.plugin.dependency
 
 import com.google.common.truth.Truth.assertThat
+import com.spotify.ruler.models.ComponentType
 import com.spotify.ruler.plugin.common.ClassNameSanitizer
 import org.junit.jupiter.api.Test
 
@@ -28,7 +29,7 @@ class DependencySanitizerTest {
         val dirty = DependencyEntry.Default("licenses.html", "project :lib")
         val clean = sanitizer.sanitize(listOf(dirty))
 
-        assertThat(clean).containsEntry("licenses.html", listOf(":lib"))
+        assertThat(clean).containsEntry("licenses.html", listOf(DependencyComponent(":lib", ComponentType.INTERNAL)))
     }
 
     @Test
@@ -36,7 +37,23 @@ class DependencySanitizerTest {
         val dirty = DependencyEntry.Class("com/spotify/MainActivity.class", "com.spotify:main:1.0.0")
         val clean = sanitizer.sanitize(listOf(dirty))
 
-        assertThat(clean).containsEntry("com.spotify.MainActivity", listOf("com.spotify:main:1.0.0"))
+        assertThat(clean).containsEntry("com.spotify.MainActivity", listOf(
+            DependencyComponent("com.spotify:main:1.0.0", ComponentType.EXTERNAL),
+        ))
+    }
+
+    @Test
+    fun `Component types are recognized`() {
+        val dirty = listOf(
+            DependencyEntry.Default("foo.txt", ":foo"),
+            DependencyEntry.Default("bar.txt", "org.bar:bar:1.0.0"),
+        )
+        val clean = sanitizer.sanitize(dirty)
+
+        assertThat(clean).containsEntry("foo.txt", listOf(DependencyComponent(":foo", ComponentType.INTERNAL)))
+        assertThat(clean).containsEntry("bar.txt", listOf(
+            DependencyComponent("org.bar:bar:1.0.0", ComponentType.EXTERNAL),
+        ))
     }
 
     @Test
@@ -48,9 +65,9 @@ class DependencySanitizerTest {
         )
         val clean = sanitizer.sanitize(dirty)
 
-        assertThat(clean).containsEntry("foo.txt", listOf(":foo"))
-        assertThat(clean).containsEntry("bar.txt", listOf(":bar"))
-        assertThat(clean).containsEntry("baz.txt", listOf(":baz"))
+        assertThat(clean).containsEntry("foo.txt", listOf(DependencyComponent(":foo", ComponentType.INTERNAL)))
+        assertThat(clean).containsEntry("bar.txt", listOf(DependencyComponent(":bar", ComponentType.INTERNAL)))
+        assertThat(clean).containsEntry("baz.txt", listOf(DependencyComponent(":baz", ComponentType.INTERNAL)))
     }
 
     @Test
@@ -62,6 +79,10 @@ class DependencySanitizerTest {
         )
         val clean = sanitizer.sanitize(dirty)
 
-        assertThat(clean).containsEntry("test.txt", listOf(":foo", ":bar", ":baz"))
+        assertThat(clean).containsEntry("test.txt", listOf(
+            DependencyComponent(":foo", ComponentType.INTERNAL),
+            DependencyComponent(":bar", ComponentType.INTERNAL),
+            DependencyComponent(":baz", ComponentType.INTERNAL),
+        ))
     }
 }

--- a/ruler-gradle-plugin/src/test/kotlin/com/spotify/ruler/plugin/report/JsonReporterTest.kt
+++ b/ruler-gradle-plugin/src/test/kotlin/com/spotify/ruler/plugin/report/JsonReporterTest.kt
@@ -20,7 +20,9 @@ import com.google.common.truth.Truth.assertThat
 import com.spotify.ruler.models.AppComponent
 import com.spotify.ruler.models.AppFile
 import com.spotify.ruler.models.AppReport
+import com.spotify.ruler.models.ComponentType
 import com.spotify.ruler.models.FileType
+import com.spotify.ruler.plugin.dependency.DependencyComponent
 import com.spotify.ruler.plugin.models.AppInfo
 import kotlinx.serialization.decodeFromString
 import kotlinx.serialization.json.Json
@@ -33,11 +35,11 @@ class JsonReporterTest {
 
     private val appInfo = AppInfo("release", "com.spotify.music", "1.2.3")
     private val components = mapOf(
-        ":app" to listOf(
+        DependencyComponent(":app", ComponentType.INTERNAL) to listOf(
             AppFile("com.spotify.MainActivity", FileType.CLASS, 100, 200),
             AppFile("/res/layout/activity_main.xml", FileType.RESOURCE, 150, 250),
         ),
-        ":lib" to listOf(
+        DependencyComponent(":lib", ComponentType.INTERNAL) to listOf(
             AppFile("/assets/license.html", FileType.ASSET, 500, 600),
         ),
     )
@@ -48,10 +50,10 @@ class JsonReporterTest {
         val report = Json.decodeFromString<AppReport>(reportFile.readText())
 
         val expected = AppReport("com.spotify.music", "1.2.3", "release", 750, 1050, listOf(
-            AppComponent(":lib", 500, 600, listOf(
+            AppComponent(":lib", ComponentType.INTERNAL, 500, 600, listOf(
                 AppFile("/assets/license.html", FileType.ASSET, 500, 600),
             )),
-            AppComponent(":app", 250, 450, listOf(
+            AppComponent(":app", ComponentType.INTERNAL, 250, 450, listOf(
                 AppFile("/res/layout/activity_main.xml", FileType.RESOURCE, 150, 250),
                 AppFile("com.spotify.MainActivity", FileType.CLASS, 100, 200),
             )),

--- a/ruler-models/src/commonMain/kotlin/com/spotify/ruler/models/ComponentType.kt
+++ b/ruler-models/src/commonMain/kotlin/com/spotify/ruler/models/ComponentType.kt
@@ -16,14 +16,8 @@
 
 package com.spotify.ruler.models
 
-import kotlinx.serialization.Serializable
-
-/** Single component of an app. Can either be a Gradle module or a dependency. */
-@Serializable
-data class AppComponent(
-    val name: String,
-    val type: ComponentType,
-    override val downloadSize: Long,
-    override val installSize: Long,
-    val files: List<AppFile>,
-) : Measurable
+/** Type of an [AppComponent]. */
+enum class ComponentType {
+    INTERNAL,
+    EXTERNAL,
+}


### PR DESCRIPTION
### What has changed
<!-- A concise description of the changes contained in this pull request. -->
Components are now assigned a `type`, showing if the component is an internal or an external component.

### Why was it changed
<!-- A concise description of why these changes are being proposed. -->
Differentiating between different types of components allows for better and more detailed analysis of the data. Visualization will follow in another PR.

### Related issues
<!-- Links to any related issues, if there are some. -->
#25 
