### PR TITLE
Fix frontend development setup

### DIFF
--- a/ruler-frontend/build.gradle.kts
+++ b/ruler-frontend/build.gradle.kts
@@ -14,6 +14,9 @@
  * limitations under the License.
  */
 
+import org.jetbrains.kotlin.gradle.targets.js.nodejs.NodeJsRootExtension
+import org.jetbrains.kotlin.gradle.targets.js.nodejs.NodeJsRootPlugin
+
 plugins {
     id("org.jetbrains.kotlin.js")
     id("com.bnorm.react.kotlin-react-function")
@@ -50,3 +53,10 @@ dependencies {
 // Make report data directories available to webpack
 registerWebpackDirectory("src/development", "development")
 registerWebpackDirectory("src/production", "production")
+
+// Workaround until https://youtrack.jetbrains.com/issue/KT-48273 is fixed
+rootProject.plugins.withType(NodeJsRootPlugin::class) {
+    rootProject.extensions.configure(NodeJsRootExtension::class) {
+        versions.webpackDevServer.version = "4.0.0"
+    }
+}

--- a/ruler-frontend/src/development/report.json
+++ b/ruler-frontend/src/development/report.json
@@ -7,6 +7,7 @@
   "components": [
     {
       "name": ":lib",
+      "type": "INTERNAL",
       "downloadSize": 500,
       "installSize": 600,
       "files": [
@@ -20,6 +21,7 @@
     },
     {
       "name": ":app",
+      "type": "INTERNAL",
       "downloadSize": 250,
       "installSize": 450,
       "files": [


### PR DESCRIPTION
### What has changed
<!-- A concise description of the changes contained in this pull request. -->
- webpack-dev-server version is now fixed at 4.0.0, until https://youtrack.jetbrains.com/issue/KT-48273 is resolved
- Type field was added to the development report data

### Why was it changed
<!-- A concise description of why these changes are being proposed. -->
- The frontend development setup (`./gradlew browserRun`) was broken, this PR fixes it

### Related issues
<!-- Links to any related issues, if there are some. -->
N/A
