### PR TITLE
Move styles to separate file

### DIFF
--- a/ruler-frontend/src/main/kotlin/com/spotify/ruler/frontend/Main.kt
+++ b/ruler-frontend/src/main/kotlin/com/spotify/ruler/frontend/Main.kt
@@ -26,6 +26,8 @@ import kotlinx.serialization.json.Json
 import react.dom.render
 
 fun main() {
+    require("./style.css")
+
     require("bootstrap/dist/css/bootstrap.css")
     require("bootstrap/dist/js/bootstrap.bundle.js")
 

--- a/ruler-frontend/src/main/resources/index.html
+++ b/ruler-frontend/src/main/resources/index.html
@@ -18,12 +18,6 @@
 <head>
     <meta charset="utf-8">
     <title>Ruler Report</title>
-
-    <style>
-        body { background-color: #eceff1 !important; }
-        .accordion-button::after { margin-left: unset !important; }
-        .me-custom { margin-right: calc(24px + 1rem); }
-    </style>
 </head>
 <body>
     <div id="root"></div>

--- a/ruler-frontend/src/main/resources/style.css
+++ b/ruler-frontend/src/main/resources/style.css
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2021 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+body {
+    background-color: #eceff1 !important;
+}
+
+.accordion-button::after {
+    margin-left: unset !important;
+}
+
+.me-custom {
+    margin-right: calc(24px + 1rem);
+}


### PR DESCRIPTION
### What has changed
<!-- A concise description of the changes contained in this pull request. -->
CSS styles are now located in a separate file.

### Why was it changed
<!-- A concise description of why these changes are being proposed. -->
Inline HTML styles are harder to work with, a separate file scales better and also has better IDE support.

### Related issues
<!-- Links to any related issues, if there are some. -->
N/A
