### PR TITLE
Switch to built-in Gradle cache action

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,16 +20,7 @@ jobs:
         with:
           distribution: adopt
           java-version: 11
-
-      - name: Cache Gradle dependencies
-        uses: actions/cache@v2
-        with:
-          path: |
-            ~/.gradle/caches
-            ~/.gradle/wrapper
-          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
-          restore-keys: |
-            ${{ runner.os }}-gradle-
+          cache: gradle
 
       - name: Publish plugin to local Maven repository
         run: ./gradlew publishToMavenLocal -PwithoutSample --no-daemon --stacktrace


### PR DESCRIPTION
### What has changed
<!-- A concise description of the changes contained in this pull request. -->
The Gradle cache action from `setup-java` is now used instead of a custom one.

### Why was it changed
<!-- A concise description of why these changes are being proposed. -->
Using existing functionality means less maintenance effort.

### Related issues
<!-- Links to any related issues, if there are some. -->
N/A
