### PR TITLE
Support testing against multiple AGP versions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,6 +11,9 @@ on:
 jobs:
   verify:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        android-gradle-plugin: [7.0.1]
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -26,6 +29,8 @@ jobs:
         run: ./gradlew publishToMavenLocal -PwithoutSample --no-daemon --stacktrace
 
       - name: Run checks
+        env:
+          ANDROID_GRADLE_PLUGIN_VERSION: ${{ matrix.android-gradle-plugin }}
         run: ./gradlew check --no-daemon --stacktrace
 
       - name: Archive sample HTML report

--- a/ruler-gradle-plugin/build.gradle.kts
+++ b/ruler-gradle-plugin/build.gradle.kts
@@ -47,7 +47,16 @@ dependencies {
     testImplementation(Dependencies.JUNIT_PARAMS)
     testImplementation(Dependencies.GOOGLE_TRUTH)
     testImplementation(Dependencies.GOOGLE_GUAVA)
-    testImplementation(Dependencies.ANDROID_GRADLE_PLUGIN)
+
+    // Allow testing against different Android Gradle plugin versions
+    testImplementation(Dependencies.ANDROID_GRADLE_PLUGIN) {
+        val version = System.getenv("ANDROID_GRADLE_PLUGIN_VERSION")
+        if (version != null) {
+            version {
+                strictly(version)
+            }
+        }
+    }
 }
 
 // Include the output of the frontend JS compilation in the plugin resources


### PR DESCRIPTION
### What has changed
<!-- A concise description of the changes contained in this pull request. -->
It's now possible to run tests against multiple/different versions of the Android Gradle plugin.

### Why was it changed
<!-- A concise description of why these changes are being proposed. -->
As new versions get released, we want to make sure we stay compatible with previous releases.

### Related issues
<!-- Links to any related issues, if there are some. -->
N/A
