### PR TITLE
Add ownership tab to HTML report

### DIFF
--- a/ruler-frontend/src/development/report.json
+++ b/ruler-frontend/src/development/report.json
@@ -2,20 +2,22 @@
   "name": "com.spotify.music",
   "version": "1.2.3",
   "variant": "release",
-  "downloadSize": 850,
-  "installSize": 1250,
+  "downloadSize": 2900,
+  "installSize": 4800,
   "components": [
     {
       "name": ":lib",
       "type": "INTERNAL",
       "downloadSize": 500,
       "installSize": 600,
+      "owner": "lib-team",
       "files": [
         {
           "name": "/assets/license.html",
           "type": "ASSET",
           "downloadSize": 500,
-          "installSize": 600
+          "installSize": 600,
+          "owner": "lib-team"
         }
       ]
     },
@@ -24,18 +26,21 @@
       "type": "INTERNAL",
       "downloadSize": 250,
       "installSize": 450,
+      "owner": "app-team",
       "files": [
         {
           "name": "/res/layout/activity_main.xml",
           "type": "RESOURCE",
           "downloadSize": 150,
-          "installSize": 250
+          "installSize": 250,
+          "owner": "app-team"
         },
         {
           "name": "com.spotify.MainActivity",
           "type": "CLASS",
           "downloadSize": 100,
-          "installSize": 200
+          "installSize": 200,
+          "owner": "app-team"
         }
       ]
     },
@@ -44,12 +49,173 @@
       "type": "EXTERNAL",
       "downloadSize": 100,
       "installSize": 200,
+      "owner": "so-team",
       "files": [
         {
           "name": "/lib/arm64-v8a/libnative.so",
           "type": "NATIVE_LIB",
           "downloadSize": 100,
-          "installSize": 200
+          "installSize": 200,
+          "owner": "so-team"
+        }
+      ]
+    },
+    {
+      "name": ":sample:navigation",
+      "type": "INTERNAL",
+      "downloadSize": 100,
+      "installSize": 150,
+      "owner": "navigation-team",
+      "files": [
+        {
+          "name": "/res/navigation/nav_graph.xml",
+          "type": "RESOURCE",
+          "downloadSize": 100,
+          "installSize": 150,
+          "owner": "navigation-team"
+        }
+      ]
+    },
+    {
+      "name": ":sample:search",
+      "type": "INTERNAL",
+      "downloadSize": 200,
+      "installSize": 400,
+      "owner": "search-team",
+      "files": [
+        {
+          "name": "com.spotify.SearchFragment",
+          "type": "CLASS",
+          "downloadSize": 200,
+          "installSize": 400,
+          "owner": "search-team"
+        }
+      ]
+    },
+    {
+      "name": ":sample:database",
+      "type": "INTERNAL",
+      "downloadSize": 150,
+      "installSize": 150,
+      "owner": "database-team",
+      "files": [
+        {
+          "name": "/assets/sample.db",
+          "type": "ASSET",
+          "downloadSize": 150,
+          "installSize": 150,
+          "owner": "database-team"
+        }
+      ]
+    },{
+      "name": "com.google.dagger:dagger:2.39",
+      "type": "EXTERNAL",
+      "downloadSize": 300,
+      "installSize": 500,
+      "owner": "di-team",
+      "files": [
+        {
+          "name": "dagger.internal.InstanceFactory",
+          "type": "CLASS",
+          "downloadSize": 300,
+          "installSize": 500,
+          "owner": "di-team"
+        }
+      ]
+    },
+    {
+      "name": "androidx.room:room-runtime:2.3.0",
+      "type": "EXTERNAL",
+      "downloadSize": 300,
+      "installSize": 350,
+      "owner": "database-team",
+      "files": [
+        {
+          "name": "androidx.room.RoomDatabase",
+          "type": "CLASS",
+          "downloadSize": 300,
+          "installSize": 350,
+          "owner": "database-team"
+        }
+      ]
+    },
+    {
+      "name": ":sample:logging",
+      "type": "INTERNAL",
+      "downloadSize": 200,
+      "installSize": 700,
+      "owner": "logging-team",
+      "files": [
+        {
+          "name": "com.spotify.Logger",
+          "type": "CLASS",
+          "downloadSize": 200,
+          "installSize": 700,
+          "owner": "logging-team"
+        }
+      ]
+    },
+    {
+      "name": "androidx.core:core:1.6.0",
+      "type": "EXTERNAL",
+      "downloadSize": 300,
+      "installSize": 400,
+      "owner": "core-team",
+      "files": [
+        {
+          "name": "/res/layout/custom_dialog.xml",
+          "type": "RESOURCE",
+          "downloadSize": 300,
+          "installSize": 400,
+          "owner": "core-team"
+        }
+      ]
+    },
+    {
+      "name": ":sample:core",
+      "type": "INTERNAL",
+      "downloadSize": 200,
+      "installSize": 350,
+      "owner": "core-team",
+      "files": [
+        {
+          "name": "com.spotify.Core",
+          "type": "CLASS",
+          "downloadSize": 200,
+          "installSize": 350,
+          "owner": "core-team"
+        }
+      ]
+    },
+    {
+      "name": ":sample:performance",
+      "type": "INTERNAL",
+      "downloadSize": 100,
+      "installSize": 200,
+      "owner": "performance-team",
+      "files": [
+        {
+          "name": "com.spotify.Benchmark",
+          "type": "CLASS",
+          "downloadSize": 100,
+          "installSize": 200,
+          "owner": "performance-team"
+        }
+      ]
+    },
+    {
+      "name": ":sample:playback",
+      "type": "INTERNAL",
+      "downloadSize": 200,
+      "installSize": 350,
+      "owner": "playback-team",
+      "files": [
+        {
+          "name": "com.spotify.Playback",
+          "type": "CLASS",
+          "downloadSize": 200,
+          "installSize": 350,
+          "owner": "playback-team"
         }
       ]
     }

--- a/ruler-frontend/src/main/kotlin/com/spotify/ruler/frontend/chart/BarChartConfig.kt
+++ b/ruler-frontend/src/main/kotlin/com/spotify/ruler/frontend/chart/BarChartConfig.kt
@@ -22,6 +22,7 @@ import com.spotify.ruler.frontend.binding.TooltipAxisFormatterOptions
 import com.spotify.ruler.frontend.formatPercentage
 
 /** Chart config for bar charts. */
+@Suppress("LongParameterList")
 class BarChartConfig(
     private val chartLabels: Array<String>,
     private val chartSeries: Array<Series>,
@@ -29,6 +30,7 @@ class BarChartConfig(
     private val horizontal: Boolean = false,
     private val xAxisFormatter: NumberFormatter = Number::toString,
     private val yAxisFormatter: NumberFormatter = Number::toString,
+    private val chartSeriesTotals: LongArray? = null,
 ) : ChartConfig() {
 
     override fun getOptions() = buildOptions {
@@ -48,7 +50,11 @@ class BarChartConfig(
 
     private fun formatTooltip(number: Number, options: TooltipAxisFormatterOptions): String {
         val axisFormatter = if (horizontal) xAxisFormatter else yAxisFormatter
-        val total = options.series[options.seriesIndex].sumOf { it.toLong() }
+        val total = if (chartSeriesTotals != null) {
+            chartSeriesTotals[options.seriesIndex]
+        } else {
+            options.series[options.seriesIndex].sumOf(Number::toLong)
+        }
         return "${axisFormatter.invoke(number)} (${formatPercentage(number, total)})"
     }
 }

--- a/ruler-frontend/src/main/kotlin/com/spotify/ruler/frontend/components/Ownership.kt
+++ b/ruler-frontend/src/main/kotlin/com/spotify/ruler/frontend/components/Ownership.kt
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2021 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.spotify.ruler.frontend.components
+
+import com.bnorm.react.RFunction
+import com.spotify.ruler.frontend.binding.NumberFormatter
+import com.spotify.ruler.frontend.chart.BarChartConfig
+import com.spotify.ruler.frontend.chart.seriesOf
+import com.spotify.ruler.frontend.formatSize
+import com.spotify.ruler.models.AppComponent
+import com.spotify.ruler.models.Measurable
+import react.RBuilder
+import react.dom.div
+import react.dom.h4
+import react.dom.span
+import react.useState
+
+const val PAGE_SIZE = 10
+
+@RFunction
+fun RBuilder.ownership(components: List<AppComponent>, sizeType: Measurable.SizeType) {
+    componentOwnershipOverview(components)
+    componentOwnershipPerTeam(components, sizeType)
+}
+
+@RFunction
+fun RBuilder.componentOwnershipOverview(components: List<AppComponent>) {
+    val sizes = mutableMapOf<String, Measurable.Mutable>()
+    components.forEach { component ->
+        val owner = component.owner ?: return@forEach
+        val current = sizes.getOrPut(owner) { Measurable.Mutable(0, 0) }
+        current.downloadSize += component.downloadSize
+        current.installSize += component.installSize
+    }
+
+    val sorted = sizes.entries.sortedByDescending { (_, measurable) -> measurable.downloadSize }
+    val owners = sorted.map { (owner, _) -> owner }
+    val downloadSizes = sorted.map { (_, measurable) -> measurable.downloadSize }
+    val installSizes = sorted.map { (_, measurable) -> measurable.installSize }
+
+    pagedContent(owners.size, PAGE_SIZE) { pageStartIndex, pageEndIndex ->
+        chart(
+            title = "Ownership overview",
+            description = "Shows how much of the overall app size is owned by each owner.",
+            config = BarChartConfig(
+                chartLabels = owners.subList(pageStartIndex, pageEndIndex).toTypedArray(),
+                chartSeries = arrayOf(
+                    seriesOf("Download size", downloadSizes.subList(pageStartIndex, pageEndIndex).toLongArray()),
+                    seriesOf("Install size", installSizes.subList(pageStartIndex, pageEndIndex).toLongArray()),
+                ),
+                chartHeight = 400,
+                yAxisFormatter = ::formatSize,
+                chartSeriesTotals = longArrayOf(downloadSizes.sum(), installSizes.sum()),
+            )
+        )
+    }
+}
+
+@RFunction
+fun RBuilder.componentOwnershipPerTeam(components: List<AppComponent>, sizeType: Measurable.SizeType) {
+    val owners = components.mapNotNull(AppComponent::owner).distinct().sorted()
+    var selectedOwner by useState(owners.first())
+
+    val ownedComponents = components.filter { component -> component.owner == selectedOwner }
+
+    h4(classes = "mb-3 mt-4") { +"Components grouped by owner" }
+    dropdown(owners) { owner -> selectedOwner = owner }
+    div(classes = "row mt-4 mb-4") {
+        highlightedValue(ownedComponents.size, "Component(s)")
+        highlightedValue(ownedComponents.sumOf(AppComponent::downloadSize), "Download size", ::formatSize)
+        highlightedValue(ownedComponents.sumOf(AppComponent::installSize), "Install size", ::formatSize)
+    }
+    componentList(ownedComponents, sizeType)
+}
+
+@RFunction
+fun RBuilder.highlightedValue(value: Number, label: String, formatter: NumberFormatter = Number::toString) {
+    div(classes = "col text-center") {
+        h4 { +formatter.invoke(value) }
+        span(classes = "text-muted m-0") { +label }
+    }
+}

--- a/ruler-frontend/src/main/kotlin/com/spotify/ruler/frontend/components/Paging.kt
+++ b/ruler-frontend/src/main/kotlin/com/spotify/ruler/frontend/components/Paging.kt
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2021 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.spotify.ruler.frontend.components
+
+import com.bnorm.react.RFunction
+import kotlinx.html.js.onClickFunction
+import react.RBuilder
+import react.dom.button
+import react.dom.li
+import react.dom.ul
+import react.useState
+import kotlin.math.ceil
+import kotlin.math.min
+
+@RFunction
+fun RBuilder.pagedContent(itemCount: Int, pageSize: Int, content: RBuilder.(Int, Int) -> Unit) {
+    val pageCount = ceil(itemCount / pageSize.toFloat()).toInt()
+    var activePage by useState(1)
+
+    val pageStartIndex = pageSize * (activePage - 1)
+    val pageEndIndex = min(pageStartIndex + pageSize, itemCount)
+    content.invoke(this, pageStartIndex, pageEndIndex)
+
+    ul(classes = "pagination justify-content-center") {
+        for (page in 1..pageCount) {
+            val activeClass = if (page == activePage) "active" else ""
+            li(classes = "page-item $activeClass") {
+                button(classes = "page-link") {
+                    attrs.onClickFunction = { activePage = page }
+                    +page.toString()
+                }
+            }
+        }
+    }
+}

--- a/ruler-models/src/commonMain/kotlin/com/spotify/ruler/models/Measurable.kt
+++ b/ruler-models/src/commonMain/kotlin/com/spotify/ruler/models/Measurable.kt
@@ -33,4 +33,7 @@ interface Measurable {
         SizeType.DOWNLOAD -> downloadSize
         SizeType.INSTALL -> installSize
     }
+
+    /** A mutable [Measurable] implementation. */
+    data class Mutable(override var downloadSize: Long, override var installSize: Long) : Measurable
 }


### PR DESCRIPTION
### What has changed
<!-- A concise description of the changes contained in this pull request. -->
New tab is added to the HTML report to visualize ownership information.

### Why was it changed
<!-- A concise description of why these changes are being proposed. -->
To visualize the data added in #34. See #21 for more details.

### Related issues
<!-- Links to any related issues, if there are some. -->
Closes #21.

### Screenshot
![localhost_8080_](https://user-images.githubusercontent.com/23724790/138667377-ae18f593-b72e-4708-8bb8-31a8d2394c8f.png)


