### PR TITLE
Attribute ExternalSyntheticLambda and ExternalSyntheticOutline classes correctly

### DIFF
--- a/ruler-gradle-plugin/src/main/kotlin/com/spotify/ruler/plugin/attribution/Attributor.kt
+++ b/ruler-gradle-plugin/src/main/kotlin/com/spotify/ruler/plugin/attribution/Attributor.kt
@@ -80,6 +80,16 @@ class Attributor(private val defaultComponent: DependencyComponent) {
             }
         }
 
+        // Attribute external synthetic classes based on their simple class name
+        if (name.contains("\$\$ExternalSynthetic")) {
+            val simpleClassName = name.substringBefore("\$\$ExternalSynthetic").substringAfterLast('.')
+            val candidates = dependencies.filter { it.key.substringAfterLast('.') == simpleClassName }.values.flatten()
+            val component = candidates.distinct().singleOrNull()
+            if (component != null) {
+                return component
+            }
+        }
+
         // If everything else fails, try matching based on package name
         val packageName = name.substringBeforeLast('.')
         return getComponentForPackage(packageName, dependencies)

--- a/ruler-gradle-plugin/src/test/kotlin/com/spotify/ruler/plugin/attribution/AttributorTest.kt
+++ b/ruler-gradle-plugin/src/test/kotlin/com/spotify/ruler/plugin/attribution/AttributorTest.kt
@@ -71,6 +71,29 @@ class AttributorTest {
     }
 
     @Test
+    fun `External synthetic classes are attributed correctly`() {
+        val files = listOf(AppFile("a.TestClass\$\$ExternalSyntheticLambda1", FileType.CLASS, 100, 200))
+        val dependencies = mapOf("com.spotify.TestClass" to listOf(
+            DependencyComponent(":lib", ComponentType.INTERNAL),
+        ))
+        val map = attributor.attribute(files, dependencies)
+
+        assertThat(map).containsEntry(DependencyComponent(":lib", ComponentType.INTERNAL), files)
+    }
+
+    @Test
+    fun `External synthetic classes are not attributed if there is no unambiguous component`() {
+        val files = listOf(AppFile("a.TestClass\$\$ExternalSyntheticLambda1", FileType.CLASS, 100, 200))
+        val dependencies = mapOf(
+            "com.spotify.TestClass" to listOf(DependencyComponent(":lib", ComponentType.INTERNAL)),
+            "com.spotify.other.TestClass" to listOf(DependencyComponent(":other", ComponentType.INTERNAL)),
+        )
+        val map = attributor.attribute(files, dependencies)
+
+        assertThat(map).containsEntry(DependencyComponent(":default", ComponentType.INTERNAL), files)
+    }
+
+    @Test
     fun `Classes are attributed based on their package name`() {
         val files = listOf(AppFile("com.spotify.UnknownClass", FileType.CLASS, 100, 200))
         val dependencies = mapOf("com.spotify.MainActivity" to listOf(


### PR DESCRIPTION
### What has changed
<!-- A concise description of the changes contained in this pull request. -->
`ExternalSyntheticLamba` and `ExternalSyntheticOutline` classes are now attributed based on the simple class name of their corresponding class.

### Why was it changed
<!-- A concise description of why these changes are being proposed. -->
`ExternalSyntheticLamba` and `ExternalSyntheticOutline` classes are generated during the build since AGP 7.0.0. Because those classes are not part of component artifacts, we have to use a special rule to find the component they're coming from (like we do for Dagger classes).

### Related issues
<!-- Links to any related issues, if there are some. -->
N/A
