### PR TITLE
Align Kotlin and Java version

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -21,3 +21,7 @@ plugins {
 repositories {
     mavenCentral()
 }
+
+java {
+    toolchain.languageVersion.set(JavaLanguageVersion.of(11))
+}

--- a/ruler-gradle-plugin/build.gradle.kts
+++ b/ruler-gradle-plugin/build.gradle.kts
@@ -74,6 +74,8 @@ tasks.withType<Test> {
 
 java {
     withSourcesJar()
+
+    toolchain.languageVersion.set(JavaLanguageVersion.of(11))
 }
 
 publishing {


### PR DESCRIPTION
### What has changed
<!-- A concise description of the changes contained in this pull request. -->
Kotlin now produces JVM bytecode compatible with Java 11 instead of Java 8.

### Why was it changed
<!-- A concise description of why these changes are being proposed. -->
To align JVM bytecode versions between the Java and Kotlin plugins.

### Related issues
<!-- Links to any related issues, if there are some. -->
N/A
