### PR TITLE
Upgrade Gradle and Android Gradle Plugin

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        android-gradle-plugin: [7.0.3]
+        android-gradle-plugin: [7.0.4, 7.1.0]
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -54,7 +54,7 @@ object Dependencies {
     const val APEX_CHARTS = "apexcharts"
 
     object Versions {
-        const val ANDROID_GRADLE_PLUGIN = "7.0.3" // https://mvnrepository.com/artifact/com.android.tools.build/gradle?repo=google
+        const val ANDROID_GRADLE_PLUGIN = "7.1.0" // https://mvnrepository.com/artifact/com.android.tools.build/gradle?repo=google
         const val KOTLIN = "1.5.31" // https://mvnrepository.com/artifact/org.jetbrains.kotlin/kotlin-stdlib
         const val KOTLIN_REACT_FUNCTION = "0.6.0" // https://mvnrepository.com/artifact/com.bnorm.react.kotlin-react-function/com.bnorm.react.kotlin-react-function.gradle.plugin
         const val DETEKT_GRADLE_PLUGIN = "1.18.1" // https://mvnrepository.com/artifact/io.gitlab.arturbosch.detekt/detekt-gradle-plugin

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.3-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/ruler-gradle-plugin/src/test/kotlin/com/spotify/ruler/plugin/testutil/ProjectFixture.kt
+++ b/ruler-gradle-plugin/src/test/kotlin/com/spotify/ruler/plugin/testutil/ProjectFixture.kt
@@ -50,9 +50,19 @@ object ProjectFixture {
         buildGradle.writeText(buildGradleContent)
     }
 
-    /** Replaces a given [marker] in the source build.gradle file with the [field] from the common [dependencies]. */
+    /**
+     * Replaces a given [marker] in the source build.gradle file with the [field] from the common [dependencies]. If
+     * there is an environment variable for the given [field], the version from that will be used instead.
+     */
     private fun String.injectVersion(marker: String, field: String): String {
-        val version = dependencies.getField(field).get(dependencies).toString()
-        return replace(marker, version)
+        var dependency = dependencies.getField(field).get(dependencies).toString()
+
+        // Override the version of the dependency if an environment variable exists
+        val versionOverride = System.getenv("${field}_VERSION")
+        if (versionOverride != null) {
+            dependency = dependency.replaceAfterLast(':', versionOverride)
+        }
+
+        return replace(marker, dependency)
     }
 }

--- a/sample/app/build.gradle.kts
+++ b/sample/app/build.gradle.kts
@@ -37,7 +37,7 @@ android {
         }
     }
     lint {
-        isWarningsAsErrors = true
+        warningsAsErrors = true
     }
     packagingOptions {
         resources.excludes.add("**/*.kotlin_builtins")

--- a/sample/lib/build.gradle.kts
+++ b/sample/lib/build.gradle.kts
@@ -27,6 +27,6 @@ android {
         targetSdk = 31
     }
     lint {
-        isWarningsAsErrors = true
+        warningsAsErrors = true
     }
 }


### PR DESCRIPTION
### What has changed
<!-- A concise description of the changes contained in this pull request. -->
- Gradle was upgraded to 7.3.3
- Android Gradle Plugin was upgraded to 7.1.0
- Integration tests can now also be run against multiple AGP versions

### Why was it changed
<!-- A concise description of why these changes are being proposed. -->
- In order to stay up-to-date and compatible with latest releases
- To ensure compatibility with multiple AGP versions

### Related issues
<!-- Links to any related issues, if there are some. -->
N/A
