### PR TITLE
Fix ownership file config in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ This ownership file can be maintained manually, but in most cases it will be mor
 
 ```kotlin
 ruler {
-    ownershipFile.set("/path/to/ownership.yaml")
+    ownershipFile.set(project.file("/path/to/ownership.yaml"))
     defaultOwner.set("default-team") // unknown by default
 }
 ```


### PR DESCRIPTION
### What has changed
<!-- A concise description of the changes contained in this pull request. -->
- Configuring an ownership file is now described correctly in the README.

### Why was it changed
<!-- A concise description of why these changes are being proposed. -->
- Because it was wrong before.

### Related issues
<!-- Links to any related issues, if there are some. -->
- Closes #47 