### PR TITLE
Add support for wildcard entries in the ownership file

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,10 @@ In larger organizations, Gradle modules and dependencies are often owned by spec
 # Identifier for dependencies -> dependency shorthand without the version
 - identifier: androidx.core:core
   owner: core-team
+
+# Wildcard identifier -> matches multiple components (can be both modules or dependencies)
+- identifier: :sample:wildcard:*
+  owner: wildcard-team
 ```
 
 This ownership file can be maintained manually, but in most cases it will be more practical to generate it during the build. You can point Ruler to your YAML file in the `build.gradle`, you can also configure default owners for components missing from the ownership file:

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ buildscript {
         }
     }
     dependencies {
-        classpath("com.spotify.ruler:ruler-gradle-plugin:1.0.0")
+        classpath("com.spotify.ruler:ruler-gradle-plugin:1.1.0")
     }
 }
 ```

--- a/buildSrc/src/main/kotlin/Publish.kt
+++ b/buildSrc/src/main/kotlin/Publish.kt
@@ -24,7 +24,7 @@ import org.gradle.plugins.signing.SigningExtension
 import java.net.URI
 
 const val RULER_PLUGIN_GROUP = "com.spotify.ruler"
-const val RULER_PLUGIN_VERSION = "1.0.0" // Also adapt this version in the README
+const val RULER_PLUGIN_VERSION = "1.1.0" // Also adapt this version in the README
 
 const val EXT_POM_NAME = "POM_NAME"
 const val EXT_POM_DESCRIPTION = "POM_DESCRIPTION"

--- a/ruler-gradle-plugin/src/main/kotlin/com/spotify/ruler/plugin/ownership/OwnershipInfo.kt
+++ b/ruler-gradle-plugin/src/main/kotlin/com/spotify/ruler/plugin/ownership/OwnershipInfo.kt
@@ -25,14 +25,38 @@ import com.spotify.ruler.models.ComponentType
  * @param defaultOwner Owner which should be used if no explicit owner is defined.
  */
 class OwnershipInfo(entries: List<OwnershipEntry>, private val defaultOwner: String) {
-    private val ownershipEntries = entries.associate { entry -> entry.identifier to entry.owner }
+    private val explicitOwnershipEntries = mutableMapOf<String, String>()
+    private val wildcardOwnershipEntries = mutableMapOf<String, String>()
+
+    // Differentiate between explicit (full match) entries and wildcard entries
+    init {
+        entries.forEach { (identifier, owner) ->
+            if (identifier.endsWith('*')) {
+                wildcardOwnershipEntries[identifier.substringBeforeLast('*')] = owner
+            } else {
+                explicitOwnershipEntries[identifier] = owner
+            }
+        }
+    }
 
     /**
      * Returns the owner of a given [component]. If the owner has no explicit owner, the [defaultOwner] will be returned
      * instead.
      */
-    fun getOwner(component: String, componentType: ComponentType): String = when (componentType) {
-        ComponentType.INTERNAL -> ownershipEntries[component] ?: defaultOwner
-        ComponentType.EXTERNAL -> ownershipEntries[component.substringBeforeLast(':')] ?: defaultOwner
+    fun getOwner(component: String, componentType: ComponentType): String {
+        val owner = when (componentType) {
+            ComponentType.INTERNAL -> explicitOwnershipEntries[component]
+            ComponentType.EXTERNAL -> explicitOwnershipEntries[component.substringBeforeLast(':')]
+        }
+        return owner ?: getWildcardOwner(component) ?: defaultOwner
+    }
+
+    /** Tries to find the owner for a component with the given [component] identifier based on all wildcard entries. */
+    private fun getWildcardOwner(component: String): String? {
+        val identifier = wildcardOwnershipEntries.keys
+            .filter(component::startsWith) // Find all identifiers that match the wildcard
+            .maxByOrNull(String::length) // Take the longest one because that one is the most specific
+
+        return wildcardOwnershipEntries[identifier]
     }
 }


### PR DESCRIPTION
### What has changed
<!-- A concise description of the changes contained in this pull request. -->
- The ownership file now supports wildcard entries to match multiple components with a single entry

### Why was it changed
<!-- A concise description of why these changes are being proposed. -->
- To provide more flexible configuration options to users

### Related issues
<!-- Links to any related issues, if there are some. -->
- Closes #48
