### PR TITLE
Fail fast when device spec is not configured

### DIFF
--- a/ruler-gradle-plugin/src/main/kotlin/com/spotify/ruler/plugin/RulerPlugin.kt
+++ b/ruler-gradle-plugin/src/main/kotlin/com/spotify/ruler/plugin/RulerPlugin.kt
@@ -37,7 +37,7 @@ class RulerPlugin : Plugin<Project> {
                 val variantName = StringGroovyMethods.capitalize(variant.name)
                 project.tasks.register("analyze${variantName}Bundle", RulerTask::class.java) { task ->
                     task.appInfo.set(getAppInfo(project, variant))
-                    task.deviceSpec.set(getDeviceSpec(project, rulerExtension))
+                    task.deviceSpec.set(getDeviceSpec(rulerExtension))
 
                     task.bundleFile.set(variant.artifacts.get(SingleArtifact.BUNDLE))
                     task.mappingFile.set(variant.artifacts.get(SingleArtifact.OBFUSCATION_MAPPING_FILE))
@@ -56,16 +56,14 @@ class RulerPlugin : Plugin<Project> {
         AppInfo(
             applicationId = variant.applicationId.get(),
             versionName = variant.outputs.first().versionName.get() ?: "-",
-            variantName = variant.name
+            variantName = variant.name,
         )
     }
 
-    private fun getDeviceSpec(project: Project, extension: RulerExtension) = project.provider {
-        DeviceSpec(
-            abi = extension.abi.get(),
-            locale = extension.locale.get(),
-            screenDensity = extension.screenDensity.get(),
-            sdkVersion = extension.sdkVersion.get()
-        )
-    }
+    private fun getDeviceSpec(extension: RulerExtension) = DeviceSpec(
+        abi = extension.abi.orNull ?: error("ABI not specified."),
+        locale = extension.locale.orNull ?: error("Locale not specified."),
+        screenDensity = extension.screenDensity.orNull ?: error("Screen density not specified."),
+        sdkVersion = extension.sdkVersion.orNull ?: error("SDK version not specified."),
+    )
 }

--- a/ruler-gradle-plugin/src/test/kotlin/com/spotify/ruler/plugin/RulerIntegrationTest.kt
+++ b/ruler-gradle-plugin/src/test/kotlin/com/spotify/ruler/plugin/RulerIntegrationTest.kt
@@ -64,7 +64,8 @@ class RulerIntegrationTest {
         val buildGradle = projectDir.resolve("app/build.gradle")
         buildGradle.writeText(buildGradle.readText().substringBefore("ruler {"))
 
-        gradlew(task, expectFailure = true)
+        val tasks = gradlew(task, expectFailure = true).tasks
+        assertThat(tasks).isEmpty() // We want to fail early
     }
 
     @ParameterizedTest


### PR DESCRIPTION
### What has changed
<!-- A concise description of the changes contained in this pull request. -->
- We now fail fast if values from the device spec are missing, instead of building the app first and then failing.

### Why was it changed
<!-- A concise description of why these changes are being proposed. -->
- No need to build the app if we're anyways going to fail, better to fail faster to allow for faster iteration.

### Related issues
<!-- Links to any related issues, if there are some. -->
- Closes #53 
