### PR TITLE
Fix attribution on Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath("com.spotify.ruler:ruler-gradle-plugin:1.1.0")
+        classpath("com.spotify.ruler:ruler-gradle-plugin:1.1.1")
     }
 }
 ```

--- a/buildSrc/src/main/kotlin/Publish.kt
+++ b/buildSrc/src/main/kotlin/Publish.kt
@@ -24,7 +24,7 @@ import org.gradle.plugins.signing.SigningExtension
 import java.net.URI
 
 const val RULER_PLUGIN_GROUP = "com.spotify.ruler"
-const val RULER_PLUGIN_VERSION = "1.1.0" // Also adapt this version in the README
+const val RULER_PLUGIN_VERSION = "1.1.1" // Also adapt this version in the README
 
 const val EXT_POM_NAME = "POM_NAME"
 const val EXT_POM_DESCRIPTION = "POM_DESCRIPTION"

--- a/ruler-gradle-plugin/src/main/kotlin/com/spotify/ruler/plugin/dependency/DependencySanitizer.kt
+++ b/ruler-gradle-plugin/src/main/kotlin/com/spotify/ruler/plugin/dependency/DependencySanitizer.kt
@@ -51,7 +51,10 @@ class DependencySanitizer(private val classNameSanitizer: ClassNameSanitizer) {
                 val name = classNameSanitizer.sanitize(entry.name)
                 DependencyEntry.Class(name, component)
             }
-            is DependencyEntry.Default -> entry.copy(component = component)
+            is DependencyEntry.Default -> {
+                val name = entry.name.replace('\\', '/') // Convert Windows-style paths to UNIX-style paths
+                DependencyEntry.Default(name, component)
+            }
         }
     }
 

--- a/ruler-gradle-plugin/src/test/kotlin/com/spotify/ruler/plugin/dependency/DependencySanitizerTest.kt
+++ b/ruler-gradle-plugin/src/test/kotlin/com/spotify/ruler/plugin/dependency/DependencySanitizerTest.kt
@@ -85,4 +85,14 @@ class DependencySanitizerTest {
             DependencyComponent(":baz", ComponentType.INTERNAL),
         ))
     }
+
+    @Test
+    fun `Windows-style paths are converted to UNIX-style paths`() {
+        val dirty = DependencyEntry.Default("\\windows\\path\\test.txt", ":test")
+        val clean = sanitizer.sanitize(listOf(dirty))
+
+        assertThat(clean).containsEntry("/windows/path/test.txt", listOf(
+            DependencyComponent(":test", ComponentType.INTERNAL),
+        ))
+    }
 }


### PR DESCRIPTION
### What has changed
<!-- A concise description of the changes contained in this pull request. -->
- Windows-style paths (`foo\bar\baz`) are now normalized and converted to UNIX-style paths (`foo/bar/baz`) during dependency sanitization.

### Why was it changed
<!-- A concise description of why these changes are being proposed. -->
- Without this, attribution doesn't work because paths inside the APK (always UNIX-style) and paths parsed from the dependencies (OS specific) don't match up.

### Related issues
<!-- Links to any related issues, if there are some. -->
- Closes #57.
