### PR TITLE
Fix report paths in Windows console logs

### DIFF
--- a/ruler-gradle-plugin/src/main/kotlin/com/spotify/ruler/plugin/RulerTask.kt
+++ b/ruler-gradle-plugin/src/main/kotlin/com/spotify/ruler/plugin/RulerTask.kt
@@ -116,10 +116,10 @@ abstract class RulerTask : DefaultTask() {
     private fun generateReports(components: Map<DependencyComponent, List<AppFile>>, ownershipInfo: OwnershipInfo?) {
         val jsonReporter = JsonReporter()
         val jsonReport = jsonReporter.generateReport(appInfo.get(), components, ownershipInfo, reportDir.asFile.get())
-        project.logger.lifecycle("Wrote JSON report to file://${jsonReport.absolutePath}")
+        project.logger.lifecycle("Wrote JSON report to ${jsonReport.toPath().toUri()}")
 
         val htmlReporter = HtmlReporter()
         val htmlReport = htmlReporter.generateReport(jsonReport.readText(), reportDir.asFile.get())
-        project.logger.lifecycle("Wrote HTML report to file://${htmlReport.absolutePath}")
+        project.logger.lifecycle("Wrote HTML report to ${htmlReport.toPath().toUri()}")
     }
 }


### PR DESCRIPTION
### What has changed
<!-- A concise description of the changes contained in this pull request. -->
- The report paths that are printed after the reports are generated were fixed on Windows.

### Why was it changed
<!-- A concise description of why these changes are being proposed. -->
- Before this fix, paths were OS-specific (e.g. `file://C:\foo\bar.txt`), now we just use the URI to log file locations (e.g. `file://C:/foo/bar.txt`).

### Related issues
<!-- Links to any related issues, if there are some. -->
N/A
