### PR TITLE
Add the ownership tag alognside the componenet name in Brekadown tab

### DIFF
--- a/ruler-frontend-tests/src/test/kotlin/com/spotify/ruler/frontend/robots/BreakdownRobot.kt
+++ b/ruler-frontend-tests/src/test/kotlin/com/spotify/ruler/frontend/robots/BreakdownRobot.kt
@@ -16,9 +16,12 @@
 
 package com.spotify.ruler.frontend.robots
 
-import com.google.common.truth.Truth.assertThat
-import com.spotify.ruler.frontend.testutil.sibling
+import com.spotify.ruler.frontend.testutil.WAIT_DURATION
+import com.spotify.ruler.frontend.testutil.ancestor
+import com.spotify.ruler.frontend.testutil.text
 import org.openqa.selenium.WebDriver
+import org.openqa.selenium.support.ui.ExpectedConditions.visibilityOfNestedElementsLocatedBy
+import org.openqa.selenium.support.ui.WebDriverWait
 
 /** Testing robot specifically for the breakdown page. */
 class BreakdownRobot(driver: WebDriver) : BaseRobot<BreakdownRobot>(driver) {
@@ -26,7 +29,7 @@ class BreakdownRobot(driver: WebDriver) : BaseRobot<BreakdownRobot>(driver) {
 
     /** Assets that the size displayed for a given [component] matches the expected [size]. */
     fun assertComponentSize(component: String, size: String) = apply {
-        val element = driver.findElement(sibling(component))
-        assertThat(element.text).isEqualTo(size)
+        val ancestor = driver.findElement(ancestor(component))
+        WebDriverWait(driver, WAIT_DURATION).until(visibilityOfNestedElementsLocatedBy(ancestor, text(size)))
     }
 }

--- a/ruler-frontend-tests/src/test/kotlin/com/spotify/ruler/frontend/testutil/Selenium.kt
+++ b/ruler-frontend-tests/src/test/kotlin/com/spotify/ruler/frontend/testutil/Selenium.kt
@@ -28,7 +28,7 @@ fun text(text: String): By {
     return xpath("//*[text()='$text']")
 }
 
-/** Matches web elements based on the text of a sibling element. */
-fun sibling(text: String): By {
-    return xpath("//*[text()='$text']/following-sibling::*")
+/** Matches web elements based on the text of a child element. */
+fun ancestor(text: String): By {
+    return xpath("//*[text()='$text']/ancestor::*")
 }

--- a/ruler-frontend/src/main/kotlin/com/spotify/ruler/frontend/components/Breakdown.kt
+++ b/ruler-frontend/src/main/kotlin/com/spotify/ruler/frontend/components/Breakdown.kt
@@ -62,8 +62,9 @@ fun RBuilder.componentListItemHeader(id: Int, component: AppComponent, sizeType:
         button(classes = "accordion-button collapsed") {
             attrs["data-bs-toggle"] = "collapse"
             attrs["data-bs-target"] = "#module-$id-body"
-            span(classes = "font-monospace text-truncate me-2") { +component.name }
-            span(classes = "ms-auto me-3 text-nowrap") {
+            span(classes = "font-monospace text-truncate me-3") { +component.name }
+            component.owner?.let { owner -> span(classes = "badge bg-secondary me-auto") { +owner } }
+            span(classes = "ms-3 me-3 text-nowrap") {
                 +formatSize(component, sizeType)
             }
         }


### PR DESCRIPTION
### What has changed
Added the ownership tag along the name.


### Screenshot

<img width="1456" alt="ruler-ownership-layout" src="https://user-images.githubusercontent.com/46002594/171592153-34699f3d-b2b0-4bdc-82df-697865bd13df.png">

### Related issues
Closes #73 

