### PR TITLE
Fix accordion arrow location when ownershipFile not defined

### DIFF
--- a/ruler-frontend/src/main/kotlin/com/spotify/ruler/frontend/components/Breakdown.kt
+++ b/ruler-frontend/src/main/kotlin/com/spotify/ruler/frontend/components/Breakdown.kt
@@ -64,7 +64,7 @@ fun RBuilder.componentListItemHeader(id: Int, component: AppComponent, sizeType:
             attrs["data-bs-target"] = "#module-$id-body"
             span(classes = "font-monospace text-truncate me-3") { +component.name }
             component.owner?.let { owner -> span(classes = "badge bg-secondary me-auto") { +owner } }
-            span(classes = "ms-3 me-3 text-nowrap") {
+            span(classes = "ms-auto me-3 text-nowrap") {
                 +formatSize(component, sizeType)
             }
         }

--- a/ruler-frontend/src/main/kotlin/com/spotify/ruler/frontend/components/Breakdown.kt
+++ b/ruler-frontend/src/main/kotlin/com/spotify/ruler/frontend/components/Breakdown.kt
@@ -63,7 +63,7 @@ fun RBuilder.componentListItemHeader(id: Int, component: AppComponent, sizeType:
             attrs["data-bs-toggle"] = "collapse"
             attrs["data-bs-target"] = "#module-$id-body"
             span(classes = "font-monospace text-truncate me-3") { +component.name }
-            component.owner?.let { owner -> span(classes = "badge bg-secondary me-auto") { +owner } }
+            component.owner?.let { owner -> span(classes = "badge bg-secondary me-3") { +owner } }
             span(classes = "ms-auto me-3 text-nowrap") {
                 +formatSize(component, sizeType)
             }


### PR DESCRIPTION
Signed-off-by: baebae33 <baebae233333@gmail.com>

### What has changed
Span classes from "ms-3" to "ms-auto"


### Why was it changed
Accordion arrow's location is wrong when ownershipFile not defined.
```
ruler {
    abi.set("arm64-v8a")
    locale.set("en")
    screenDensity.set(480)
    sdkVersion.set(27)

//    ownershipFile.set(project.layout.projectDirectory.file("ownership.yaml"))
    defaultOwner.set("default-team")
}

```
Before:
<img width="1343" alt="image" src="https://user-images.githubusercontent.com/16750933/178012226-4f525a96-e109-4120-9a42-7faf57cf8d40.png">
Alfter:
<img width="1335" alt="image" src="https://user-images.githubusercontent.com/16750933/178012289-d16da264-a5d7-4b5d-a3bf-87409a0e5611.png">


### Related issues
N/A
