### PR TITLE
Bump Ruler version to 1.4.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath("com.spotify.ruler:ruler-gradle-plugin:1.3.0")
+        classpath("com.spotify.ruler:ruler-gradle-plugin:1.4.0")
     }
 }
 ```

--- a/buildSrc/src/main/kotlin/Publish.kt
+++ b/buildSrc/src/main/kotlin/Publish.kt
@@ -24,7 +24,7 @@ import org.gradle.plugins.signing.SigningExtension
 import java.net.URI
 
 const val RULER_PLUGIN_GROUP = "com.spotify.ruler"
-const val RULER_PLUGIN_VERSION = "1.3.0" // Also adapt this version in the README
+const val RULER_PLUGIN_VERSION = "1.4.0" // Also adapt this version in the README
 
 const val EXT_POM_NAME = "POM_NAME"
 const val EXT_POM_DESCRIPTION = "POM_DESCRIPTION"


### PR DESCRIPTION
### What has changed
<!-- A concise description of the changes contained in this pull request. -->
- Ruler version was bumped to 1.4.0.

### Why was it changed
<!-- A concise description of why these changes are being proposed. -->
- So we can release a new version including the latest features (with DexGuard support).

### Related issues
<!-- Links to any related issues, if there are some. -->
N/A
