### PR TITLE
Possibility to exclude the lists of files in order to have smaller reports

### DIFF
--- a/ruler-e2e-tests/src/test/kotlin/com/spotify/ruler/e2e/ReleaseReportTest.kt
+++ b/ruler-e2e-tests/src/test/kotlin/com/spotify/ruler/e2e/ReleaseReportTest.kt
@@ -88,8 +88,8 @@ class ReleaseReportTest {
             downloadSize += component.downloadSize
             installSize += component.installSize
         }
-        assertThat(downloadSize).isEqualTo(report.downloadSize)
-        assertThat(installSize).isEqualTo(report.installSize)
+        assertThat(downloadSize).isEqualTo(report.insights.appDownloadSize)
+        assertThat(installSize).isEqualTo(report.insights.appInstallSize)
     }
 
     @Test

--- a/ruler-frontend/src/main/kotlin/com/spotify/ruler/frontend/components/Breakdown.kt
+++ b/ruler-frontend/src/main/kotlin/com/spotify/ruler/frontend/components/Breakdown.kt
@@ -52,8 +52,12 @@ fun RBuilder.containerList(containers: List<FileContainer>, sizeType: Measurable
 @Suppress("UNUSED_PARAMETER")
 fun RBuilder.containerListItem(id: Int, container: FileContainer, sizeType: Measurable.SizeType, @RKey key: String) {
     div(classes = "accordion-item") {
-        containerListItemHeader(id, container, sizeType)
-        containerListItemBody(id, container, sizeType)
+        if (container.files.isEmpty()) {
+            containerWithoutFilesListItemHeader(container, sizeType)
+        } else {
+            containerListItemHeader(id, container, sizeType)
+            containerListItemBody(id, container, sizeType)
+        }
     }
 }
 
@@ -63,12 +67,24 @@ fun RBuilder.containerListItemHeader(id: Int, container: FileContainer, sizeType
         button(classes = "accordion-button collapsed") {
             attrs["data-bs-toggle"] = "collapse"
             attrs["data-bs-target"] = "#module-$id-body"
-            span(classes = "font-monospace text-truncate me-3") { +container.name }
-            container.owner?.let { owner -> span(classes = "badge bg-secondary me-3") { +owner.name } }
-            span(classes = "ms-auto me-3 text-nowrap") {
-                +formatSize(container, sizeType)
-            }
+            containerHeader(container, sizeType)
         }
+    }
+}
+
+@RFunction
+fun RBuilder.containerWithoutFilesListItemHeader(container: FileContainer, sizeType: Measurable.SizeType) {
+    div(classes = "list-group-item d-flex border-0") {
+        containerHeader(container, sizeType)
+    }
+}
+
+@RFunction
+fun RBuilder.containerHeader(container: FileContainer, sizeType: Measurable.SizeType) {
+    span(classes = "font-monospace text-truncate me-3") { +container.name }
+    container.owner?.let { owner -> span(classes = "badge bg-secondary me-3") { +owner.name } }
+    span(classes = "ms-auto me-3 text-nowrap") {
+        +formatSize(container, sizeType)
     }
 }
 

--- a/ruler-frontend/src/main/kotlin/com/spotify/ruler/frontend/components/Breakdown.kt
+++ b/ruler-frontend/src/main/kotlin/com/spotify/ruler/frontend/components/Breakdown.kt
@@ -64,7 +64,7 @@ fun RBuilder.containerListItemHeader(id: Int, container: FileContainer, sizeType
             attrs["data-bs-toggle"] = "collapse"
             attrs["data-bs-target"] = "#module-$id-body"
             span(classes = "font-monospace text-truncate me-3") { +container.name }
-            container.owner?.let { owner -> span(classes = "badge bg-secondary me-3") { +owner } }
+            container.owner?.let { owner -> span(classes = "badge bg-secondary me-3") { +owner.name } }
             span(classes = "ms-auto me-3 text-nowrap") {
                 +formatSize(container, sizeType)
             }

--- a/ruler-frontend/src/main/kotlin/com/spotify/ruler/frontend/components/Common.kt
+++ b/ruler-frontend/src/main/kotlin/com/spotify/ruler/frontend/components/Common.kt
@@ -44,13 +44,13 @@ import react.useState
 fun RBuilder.report(report: AppReport) {
     val (sizeType, setSizeType) = useState(Measurable.SizeType.DOWNLOAD)
 
-    val hasOwnershipInfo = report.components.any { component -> component.owner != null }
+    val hasOwnershipInfo = report.ownershipOverview?.isNotEmpty() == true
     val hasDynamicFeatures = report.dynamicFeatures.isNotEmpty()
 
     val tabs = listOf(
         Tab("/", "Breakdown") { breakdown(report.components, sizeType) },
         Tab("/insights", "Insights") { insights(report.insights) },
-        Tab("/ownership", "Ownership", hasOwnershipInfo) { ownership(report.components, sizeType) },
+        Tab("/ownership", "Ownership", hasOwnershipInfo) { ownership(report.components, sizeType, report.ownershipOverview!!) },
         Tab("/dynamic", "Dynamic features", hasDynamicFeatures) { dynamicFeatures(report.dynamicFeatures, sizeType) },
     )
 

--- a/ruler-frontend/src/main/kotlin/com/spotify/ruler/frontend/components/Common.kt
+++ b/ruler-frontend/src/main/kotlin/com/spotify/ruler/frontend/components/Common.kt
@@ -49,7 +49,7 @@ fun RBuilder.report(report: AppReport) {
 
     val tabs = listOf(
         Tab("/", "Breakdown") { breakdown(report.components, sizeType) },
-        Tab("/insights", "Insights") { insights(report.components) },
+        Tab("/insights", "Insights") { insights(report.insights) },
         Tab("/ownership", "Ownership", hasOwnershipInfo) { ownership(report.components, sizeType) },
         Tab("/dynamic", "Dynamic features", hasDynamicFeatures) { dynamicFeatures(report.dynamicFeatures, sizeType) },
     )
@@ -74,8 +74,8 @@ fun RBuilder.header(report: AppReport) {
             h3 { +report.name }
             span(classes = "text-muted") { +"Version ${report.version} (${report.variant})" }
         }
-        headerSizeItem(report.downloadSize, "Download size")
-        headerSizeItem(report.installSize, "Install size")
+        headerSizeItem(report.insights.appDownloadSize, "Download size")
+        headerSizeItem(report.insights.appInstallSize, "Install size")
     }
 }
 

--- a/ruler-frontend/src/main/kotlin/com/spotify/ruler/frontend/components/Common.kt
+++ b/ruler-frontend/src/main/kotlin/com/spotify/ruler/frontend/components/Common.kt
@@ -50,7 +50,7 @@ fun RBuilder.report(report: AppReport) {
     val tabs = listOf(
         Tab("/", "Breakdown") { breakdown(report.components, sizeType) },
         Tab("/insights", "Insights") { insights(report.insights) },
-        Tab("/ownership", "Ownership", hasOwnershipInfo) { ownership(report.components, sizeType, report.ownershipOverview!!) },
+        Tab("/ownership", "Ownership", hasOwnershipInfo) { ownership(report.components, sizeType, report.ownershipOverview ?: emptyMap()) },
         Tab("/dynamic", "Dynamic features", hasDynamicFeatures) { dynamicFeatures(report.dynamicFeatures, sizeType) },
     )
 

--- a/ruler-frontend/src/main/kotlin/com/spotify/ruler/frontend/components/Insights.kt
+++ b/ruler-frontend/src/main/kotlin/com/spotify/ruler/frontend/components/Insights.kt
@@ -22,8 +22,11 @@ import com.spotify.ruler.frontend.chart.ChartConfig
 import com.spotify.ruler.frontend.chart.BarChartConfig
 import com.spotify.ruler.frontend.formatSize
 import com.spotify.ruler.frontend.chart.seriesOf
-import com.spotify.ruler.models.AppComponent
-import com.spotify.ruler.models.Measurable
+import com.spotify.ruler.models.ComponentType
+import com.spotify.ruler.models.FileType
+import com.spotify.ruler.models.Insights
+import com.spotify.ruler.models.TypeInsights
+import com.spotify.ruler.models.ResourceType
 import kotlinx.browser.document
 import kotlinx.html.id
 import react.RBuilder
@@ -33,30 +36,30 @@ import react.dom.p
 import react.useEffect
 
 @RFunction
-fun RBuilder.insights(components: List<AppComponent>) {
+fun RBuilder.insights(insights: Insights) {
     div(classes = "row mb-3") {
-        fileTypeGraphs(components)
+        fileTypeGraphs(insights.fileTypeInsights)
     }
     div(classes = "row") {
-        componentTypeGraphs(components)
+        componentTypeGraphs(insights.componentTypeInsights)
     }
     div(classes = "row") {
-        resourcesTypeGraphs(components)
+        resourcesTypeGraphs(insights.resourcesTypeInsights)
     }
 }
 
 @RFunction
-fun RBuilder.fileTypeGraphs(components: List<AppComponent>) {
-    val labels = arrayOf("Classes", "Resources", "Assets", "Native libraries", "Other")
+fun RBuilder.fileTypeGraphs(fileTypeInsights: Map<FileType, TypeInsights>) {
+    val labels = FileType.values().map { it.label }.toTypedArray()
     val downloadSizes = LongArray(labels.size)
     val installSizes = LongArray(labels.size)
     val fileCounts = LongArray(labels.size)
 
-    components.flatMap(AppComponent::files).forEach { file ->
-        val index = file.type.ordinal
-        downloadSizes[index] += file.getSize(Measurable.SizeType.DOWNLOAD)
-        installSizes[index] += file.getSize(Measurable.SizeType.INSTALL)
-        fileCounts[index]++
+    fileTypeInsights.forEach { (fileType, insights) ->
+        val index = fileType.ordinal
+        downloadSizes[index] = insights.downloadSize
+        installSizes[index] = insights.installSize
+        fileCounts[index] = insights.count
     }
 
     chart(
@@ -83,17 +86,17 @@ fun RBuilder.fileTypeGraphs(components: List<AppComponent>) {
 }
 
 @RFunction
-fun RBuilder.componentTypeGraphs(components: List<AppComponent>) {
-    val labels = arrayOf("Internal", "External")
+fun RBuilder.componentTypeGraphs(componentTypeInsights: Map<ComponentType, TypeInsights>) {
+    val labels = ComponentType.values().map { it.label }.toTypedArray()
     val downloadSizes = LongArray(labels.size)
     val installSizes = LongArray(labels.size)
     val fileCounts = LongArray(labels.size)
 
-    components.forEach { component ->
-        val index = component.type.ordinal
-        downloadSizes[index] += component.getSize(Measurable.SizeType.DOWNLOAD)
-        installSizes[index] += component.getSize(Measurable.SizeType.INSTALL)
-        fileCounts[index]++
+    componentTypeInsights.forEach { (componentType, insights) ->
+        val index = componentType.ordinal
+        downloadSizes[index] = insights.downloadSize
+        installSizes[index] = insights.installSize
+        fileCounts[index] = insights.count
     }
 
     chart(
@@ -122,17 +125,17 @@ fun RBuilder.componentTypeGraphs(components: List<AppComponent>) {
 }
 
 @RFunction
-fun RBuilder.resourcesTypeGraphs(components: List<AppComponent>) {
-    val labels = arrayOf("Drawable", "Layout", "Raw", "Values", "Font", "Other")
+fun RBuilder.resourcesTypeGraphs(resourcesTypeInsights: Map<ResourceType, TypeInsights>) {
+    val labels = ResourceType.values().map { it.label }.toTypedArray()
     val downloadSizes = LongArray(labels.size)
     val installSizes = LongArray(labels.size)
     val fileCounts = LongArray(labels.size)
 
-    components.flatMap(AppComponent::files).filter { it.resourceType != null }.forEach { file ->
-        val index = file.resourceType!!.ordinal
-        downloadSizes[index] += file.getSize(Measurable.SizeType.DOWNLOAD)
-        installSizes[index] += file.getSize(Measurable.SizeType.INSTALL)
-        fileCounts[index]++
+    resourcesTypeInsights.forEach { (resourceType, insights) ->
+        val index = resourceType.ordinal
+        downloadSizes[index] = insights.downloadSize
+        installSizes[index] = insights.installSize
+        fileCounts[index] = insights.count
     }
 
     chart(

--- a/ruler-frontend/src/main/kotlin/com/spotify/ruler/frontend/components/Ownership.kt
+++ b/ruler-frontend/src/main/kotlin/com/spotify/ruler/frontend/components/Ownership.kt
@@ -24,8 +24,8 @@ import com.spotify.ruler.frontend.formatSize
 import com.spotify.ruler.models.AppComponent
 import com.spotify.ruler.models.ComponentType
 import com.spotify.ruler.models.Measurable
-import com.spotify.ruler.models.OwnedSize
-import com.spotify.ruler.models.Owner
+import com.spotify.ruler.models.OwnedComponentSize
+import com.spotify.ruler.models.ComponentOwner
 import com.spotify.ruler.models.OwnershipOverview
 import react.RBuilder
 import react.dom.div
@@ -109,9 +109,9 @@ fun RBuilder.componentOwnershipPerTeam(
             downloadSize = remainingOwnedDownloadSize,
             installSize = remainingOwnedInstallSize,
             files = remainingOwnedFiles.toList(),
-            owner = Owner(
+            owner = ComponentOwner(
                 name = selectedOwner,
-                ownedSize = OwnedSize(
+                ownedSize = OwnedComponentSize(
                     downloadSize = remainingOwnedDownloadSize,
                     installSize = remainingOwnedInstallSize,
                 ),

--- a/ruler-gradle-plugin/src/main/kotlin/com/spotify/ruler/plugin/RulerExtension.kt
+++ b/ruler-gradle-plugin/src/main/kotlin/com/spotify/ruler/plugin/RulerExtension.kt
@@ -29,8 +29,11 @@ open class RulerExtension(objects: ObjectFactory) {
     val ownershipFile: RegularFileProperty = objects.fileProperty()
     val defaultOwner: Property<String> = objects.property(String::class.java)
 
+    val shouldExcludeFileListing: Property<Boolean> = objects.property(Boolean::class.java)
+
     // Set up default values
     init {
         defaultOwner.convention("unknown")
+        shouldExcludeFileListing.convention(false)
     }
 }

--- a/ruler-gradle-plugin/src/main/kotlin/com/spotify/ruler/plugin/RulerPlugin.kt
+++ b/ruler-gradle-plugin/src/main/kotlin/com/spotify/ruler/plugin/RulerPlugin.kt
@@ -53,6 +53,8 @@ class RulerPlugin : Plugin<Project> {
                     task.workingDir.set(project.layout.buildDirectory.dir("intermediates/ruler/${variant.name}"))
                     task.reportDir.set(project.layout.buildDirectory.dir("reports/ruler/${variant.name}"))
 
+                    task.shouldExcludeFileListing.set(rulerExtension.shouldExcludeFileListing)
+
                     // Add explicit dependency to support DexGuard
                     task.dependsOn("bundle$variantName")
                 }
@@ -64,7 +66,7 @@ class RulerPlugin : Plugin<Project> {
     private fun getAppInfo(project: Project, variant: ApplicationVariant) = project.provider {
         AppInfo(
             applicationId = variant.applicationId.get(),
-            versionName = variant.outputs.first().versionName.get() ?: "-",
+            versionName = variant.outputs.first().versionName.orNull ?: "-",
             variantName = variant.name,
         )
     }

--- a/ruler-gradle-plugin/src/main/kotlin/com/spotify/ruler/plugin/RulerTask.kt
+++ b/ruler-gradle-plugin/src/main/kotlin/com/spotify/ruler/plugin/RulerTask.kt
@@ -69,6 +69,9 @@ abstract class RulerTask : DefaultTask() {
     @get:Input
     abstract val defaultOwner: Property<String>
 
+    @get:Input
+    abstract val shouldExcludeFileListing: Property<Boolean>
+
     @get:OutputDirectory
     abstract val workingDir: DirectoryProperty
 
@@ -132,7 +135,14 @@ abstract class RulerTask : DefaultTask() {
         val reportDir = reportDir.asFile.get()
 
         val jsonReporter = JsonReporter()
-        val jsonReport = jsonReporter.generateReport(appInfo.get(), components, features, ownershipInfo, reportDir)
+        val jsonReport = jsonReporter.generateReport(
+            appInfo.get(),
+            components,
+            features,
+            ownershipInfo,
+            shouldExcludeFileListing.get(),
+            reportDir,
+        )
         project.logger.lifecycle("Wrote JSON report to ${jsonReport.toPath().toUri()}")
 
         val htmlReporter = HtmlReporter()

--- a/ruler-gradle-plugin/src/main/kotlin/com/spotify/ruler/plugin/report/JsonReporter.kt
+++ b/ruler-gradle-plugin/src/main/kotlin/com/spotify/ruler/plugin/report/JsonReporter.kt
@@ -55,6 +55,7 @@ class JsonReporter {
         components: Map<DependencyComponent, List<AppFile>>,
         features: Map<String, List<AppFile>>,
         ownershipInfo: OwnershipInfo?,
+        shouldExcludeFileListing: Boolean,
         targetDir: File
     ): File {
         val appComponents = getAppComponents(components, ownershipInfo)
@@ -62,8 +63,9 @@ class JsonReporter {
             name = appInfo.applicationId,
             version = appInfo.versionName,
             variant = appInfo.variantName,
-            components = appComponents,
-            dynamicFeatures = getDynamicFeatures(features, ownershipInfo),
+            components = appComponents.excludeComponentFilesIfNeeded(shouldExcludeFileListing),
+            dynamicFeatures = getDynamicFeatures(features, ownershipInfo)
+                .excludeDyamicFeatureFilesIfNeeded(shouldExcludeFileListing),
             insights = getInsights(components, appComponents),
             ownershipOverview = ownershipInfo?.let { getOwnershipOverview(appComponents) },
         )
@@ -234,4 +236,22 @@ class JsonReporter {
 
         return overview
     }
+
+    private fun List<AppComponent>.excludeComponentFilesIfNeeded(
+        shouldExcludeFileListing: Boolean
+    ): List<AppComponent> =
+        if (shouldExcludeFileListing) {
+            map { it.copy(files = emptyList()) }
+        } else {
+            this
+        }
+
+    private fun List<DynamicFeature>.excludeDyamicFeatureFilesIfNeeded(
+        shouldExcludeFileListing: Boolean
+    ): List<DynamicFeature> =
+        if (shouldExcludeFileListing) {
+            map { it.copy(files = emptyList()) }
+        } else {
+            this
+        }
 }

--- a/ruler-gradle-plugin/src/main/kotlin/com/spotify/ruler/plugin/report/JsonReporter.kt
+++ b/ruler-gradle-plugin/src/main/kotlin/com/spotify/ruler/plugin/report/JsonReporter.kt
@@ -25,8 +25,8 @@ import com.spotify.ruler.models.FileType
 import com.spotify.ruler.models.Insights
 import com.spotify.ruler.models.Measurable
 import com.spotify.ruler.models.MutableTypeInsights
-import com.spotify.ruler.models.OwnedSize
-import com.spotify.ruler.models.Owner
+import com.spotify.ruler.models.OwnedComponentSize
+import com.spotify.ruler.models.ComponentOwner
 import com.spotify.ruler.models.OwnershipOverview
 import com.spotify.ruler.models.ResourceType
 import com.spotify.ruler.models.TypeInsights
@@ -47,6 +47,7 @@ class JsonReporter {
      * @param appInfo General info about the analyzed app.
      * @param components Map of app component names to their respective files
      * @param ownershipInfo Optional info about the owners of components.
+     * @param shouldExcludeFileListing Flag to determine if file listing should be included in the report
      * @param targetDir Directory where the generated report will be located
      * @return Generated JSON report file
      */
@@ -130,7 +131,7 @@ class JsonReporter {
     private fun getOwner(
         componentOwnerName: String,
         files: List<AppFile>,
-    ): Owner {
+    ): ComponentOwner {
         var ownedDownloadSize = 0L
         var ownedInstallSize = 0L
         files.filter { it.owner == componentOwnerName }.forEach { ownedFile ->
@@ -138,9 +139,9 @@ class JsonReporter {
             ownedInstallSize += ownedFile.installSize
         }
 
-        return Owner(
+        return ComponentOwner(
             name = componentOwnerName,
-            ownedSize = OwnedSize(
+            ownedSize = OwnedComponentSize(
                 downloadSize = ownedDownloadSize,
                 installSize = ownedInstallSize,
             )

--- a/ruler-gradle-plugin/src/main/kotlin/com/spotify/ruler/plugin/report/JsonReporter.kt
+++ b/ruler-gradle-plugin/src/main/kotlin/com/spotify/ruler/plugin/report/JsonReporter.kt
@@ -27,6 +27,7 @@ import com.spotify.ruler.models.Measurable
 import com.spotify.ruler.models.MutableTypeInsights
 import com.spotify.ruler.models.OwnedComponentSize
 import com.spotify.ruler.models.ComponentOwner
+import com.spotify.ruler.models.MutableOwnershipOverview
 import com.spotify.ruler.models.OwnershipOverview
 import com.spotify.ruler.models.ResourceType
 import com.spotify.ruler.models.TypeInsights
@@ -210,13 +211,13 @@ class JsonReporter {
     }
 
     private fun getOwnershipOverview(appComponents: List<AppComponent>): Map<String, OwnershipOverview> {
-        val overview = mutableMapOf<String, OwnershipOverview>()
+        val overview = mutableMapOf<String, MutableOwnershipOverview>()
 
         appComponents.forEach { component ->
             component.files.forEach { file ->
                 file.owner?.let { fileOwner ->
                     val current = overview.getOrPut(fileOwner) {
-                        OwnershipOverview(
+                        MutableOwnershipOverview(
                             totalDownloadSize = 0,
                             totalInstallSize = 0,
                             filesCount = 0,
@@ -235,7 +236,16 @@ class JsonReporter {
             }
         }
 
-        return overview
+        return overview.map {
+            val (owner, ownershipOverview) = it
+            owner to OwnershipOverview(
+                totalDownloadSize = ownershipOverview.totalDownloadSize,
+                totalInstallSize = ownershipOverview.totalInstallSize,
+                filesCount = ownershipOverview.filesCount,
+                filesFromNotOwnedComponentsDownloadSize = ownershipOverview.filesFromNotOwnedComponentsDownloadSize,
+                filesFromNotOwnedComponentsInstallSize = ownershipOverview.filesFromNotOwnedComponentsInstallSize,
+            )
+        }.toMap()
     }
 
     private fun List<AppComponent>.excludeComponentFilesIfNeeded(

--- a/ruler-gradle-plugin/src/test/kotlin/com/spotify/ruler/plugin/report/JsonReporterTest.kt
+++ b/ruler-gradle-plugin/src/test/kotlin/com/spotify/ruler/plugin/report/JsonReporterTest.kt
@@ -24,8 +24,8 @@ import com.spotify.ruler.models.ComponentType
 import com.spotify.ruler.models.DynamicFeature
 import com.spotify.ruler.models.FileType
 import com.spotify.ruler.models.Insights
-import com.spotify.ruler.models.OwnedSize
-import com.spotify.ruler.models.Owner
+import com.spotify.ruler.models.OwnedComponentSize
+import com.spotify.ruler.models.ComponentOwner
 import com.spotify.ruler.models.OwnershipOverview
 import com.spotify.ruler.models.ResourceType
 import com.spotify.ruler.models.TypeInsights
@@ -91,7 +91,7 @@ class JsonReporterTest {
                     files = listOf(
                         AppFile("/assets/license.html", FileType.ASSET, 500, 600, "default-team"),
                     ),
-                    owner = Owner(name = "default-team", ownedSize = OwnedSize(downloadSize = 500, installSize = 600))
+                    owner = ComponentOwner(name = "default-team", ownedSize = OwnedComponentSize(downloadSize = 500, installSize = 600))
                 ),
                 AppComponent(
                     name = ":app",
@@ -103,7 +103,7 @@ class JsonReporterTest {
                         AppFile("com.spotify.MainActivity", FileType.CLASS, 100, 200, "app-team"),
                         AppFile("com.spotify.LoginActivity", FileType.CLASS, 50, 100, "login-team"),
                     ),
-                    owner = Owner(name = "app-team", ownedSize = OwnedSize(downloadSize = 250, installSize = 450))
+                    owner = ComponentOwner(name = "app-team", ownedSize = OwnedComponentSize(downloadSize = 250, installSize = 450))
                 ),
             ),
             dynamicFeatures = listOf(
@@ -115,7 +115,7 @@ class JsonReporterTest {
                         AppFile("com.spotify.DynamicActivity", FileType.CLASS, 200, 300, "dynamic-team"),
                         AppFile("/res/layout/activity_dynamic.xml", FileType.RESOURCE, 100, 250, "dynamic-team", ResourceType.LAYOUT),
                     ),
-                    owner = Owner(name = "dynamic-team", ownedSize = OwnedSize(downloadSize = 300, installSize = 550))
+                    owner = ComponentOwner(name = "dynamic-team", ownedSize = OwnedComponentSize(downloadSize = 300, installSize = 550))
                 ),
             ),
             insights = Insights(

--- a/ruler-gradle-plugin/src/test/kotlin/com/spotify/ruler/plugin/report/JsonReporterTest.kt
+++ b/ruler-gradle-plugin/src/test/kotlin/com/spotify/ruler/plugin/report/JsonReporterTest.kt
@@ -23,7 +23,9 @@ import com.spotify.ruler.models.AppReport
 import com.spotify.ruler.models.ComponentType
 import com.spotify.ruler.models.DynamicFeature
 import com.spotify.ruler.models.FileType
+import com.spotify.ruler.models.Insights
 import com.spotify.ruler.models.ResourceType
+import com.spotify.ruler.models.TypeInsights
 import com.spotify.ruler.plugin.dependency.DependencyComponent
 import com.spotify.ruler.plugin.models.AppInfo
 import com.spotify.ruler.plugin.ownership.OwnershipEntry
@@ -68,27 +70,68 @@ class JsonReporterTest {
         val reportFile = reporter.generateReport(appInfo, components, features, ownershipInfo, targetDir)
         val report = Json.decodeFromString<AppReport>(reportFile.readText())
 
-        val expected = AppReport("com.spotify.music", "1.2.3", "release", 750, 1050, listOf(
-            AppComponent(":lib", ComponentType.INTERNAL, 500, 600, listOf(
-                AppFile("/assets/license.html", FileType.ASSET, 500, 600, "default-team"),
-            ), "default-team"),
-            AppComponent(":app", ComponentType.INTERNAL, 250, 450, listOf(
-                AppFile("/res/layout/activity_main.xml", FileType.RESOURCE, 150, 250, "app-team", ResourceType.LAYOUT),
-                AppFile("com.spotify.MainActivity", FileType.CLASS, 100, 200, "app-team"),
-            ), "app-team"),
-        ), listOf(
-            DynamicFeature("dynamic", 300, 550, listOf(
-                AppFile("com.spotify.DynamicActivity", FileType.CLASS, 200, 300, "dynamic-team"),
-                AppFile(
-                    "/res/layout/activity_dynamic.xml",
-                    FileType.RESOURCE,
-                    100,
-                    250,
-                    "dynamic-team",
-                    ResourceType.LAYOUT
+        val expected = AppReport(
+            name = "com.spotify.music",
+            version = "1.2.3",
+            variant = "release",
+            components = listOf(
+                AppComponent(":lib", ComponentType.INTERNAL, 500, 600, listOf(
+                    AppFile("/assets/license.html", FileType.ASSET, 500, 600, "default-team"),
+                ), "default-team"),
+                AppComponent(":app", ComponentType.INTERNAL, 250, 450, listOf(
+                    AppFile("/res/layout/activity_main.xml", FileType.RESOURCE, 150, 250, "app-team", ResourceType.LAYOUT),
+                    AppFile("com.spotify.MainActivity", FileType.CLASS, 100, 200, "app-team"),
+                ), "app-team"),
+            ),
+            dynamicFeatures = listOf(
+                DynamicFeature("dynamic", 300, 550, listOf(
+                    AppFile("com.spotify.DynamicActivity", FileType.CLASS, 200, 300, "dynamic-team"),
+                    AppFile(
+                        "/res/layout/activity_dynamic.xml",
+                        FileType.RESOURCE,
+                        100,
+                        250,
+                        "dynamic-team",
+                        ResourceType.LAYOUT
+                    ),
+                ), "dynamic-team"),
+            ),
+            insights = Insights(
+                appDownloadSize = 750,
+                appInstallSize = 1050,
+                fileTypeInsights = mapOf(
+                    FileType.CLASS to TypeInsights(
+                        downloadSize = 100,
+                        installSize = 200,
+                        count = 1
+                    ),
+                    FileType.RESOURCE to TypeInsights(
+                        downloadSize = 150,
+                        installSize = 250,
+                        count = 1
+                    ),
+                    FileType.ASSET to TypeInsights(
+                        downloadSize = 500,
+                        installSize = 600,
+                        count = 1
+                    )
                 ),
-            ), "dynamic-team"),
-        ))
+                componentTypeInsights = mapOf(
+                    ComponentType.INTERNAL to TypeInsights(
+                        downloadSize = 750,
+                        installSize = 1050,
+                        count = 2
+                    )
+                ),
+                resourcesTypeInsights = mapOf(
+                    ResourceType.LAYOUT to TypeInsights(
+                        downloadSize = 150,
+                        installSize = 250,
+                        count = 1
+                    )
+                ),
+            )
+        )
         assertThat(report).isEqualTo(expected)
     }
 

--- a/ruler-models/src/commonMain/kotlin/com/spotify/ruler/models/AppComponent.kt
+++ b/ruler-models/src/commonMain/kotlin/com/spotify/ruler/models/AppComponent.kt
@@ -26,5 +26,5 @@ data class AppComponent(
     override val downloadSize: Long,
     override val installSize: Long,
     override val files: List<AppFile>,
-    override val owner: String? = null,
+    override val owner: Owner? = null,
 ) : FileContainer

--- a/ruler-models/src/commonMain/kotlin/com/spotify/ruler/models/AppComponent.kt
+++ b/ruler-models/src/commonMain/kotlin/com/spotify/ruler/models/AppComponent.kt
@@ -26,5 +26,5 @@ data class AppComponent(
     override val downloadSize: Long,
     override val installSize: Long,
     override val files: List<AppFile>,
-    override val owner: Owner? = null,
+    override val owner: ComponentOwner? = null,
 ) : FileContainer

--- a/ruler-models/src/commonMain/kotlin/com/spotify/ruler/models/AppReport.kt
+++ b/ruler-models/src/commonMain/kotlin/com/spotify/ruler/models/AppReport.kt
@@ -24,8 +24,7 @@ data class AppReport(
     val name: String,
     val version: String,
     val variant: String,
-    override val downloadSize: Long,
-    override val installSize: Long,
     val components: List<AppComponent>,
     val dynamicFeatures: List<DynamicFeature>,
-) : Measurable
+    val insights: Insights,
+)

--- a/ruler-models/src/commonMain/kotlin/com/spotify/ruler/models/ComponentOwner.kt
+++ b/ruler-models/src/commonMain/kotlin/com/spotify/ruler/models/ComponentOwner.kt
@@ -18,8 +18,11 @@ package com.spotify.ruler.models
 
 import kotlinx.serialization.Serializable
 
+/** Representation of the relation between the owner of a component
+ * and the corresponding OwnedComponentSize
+ * */
 @Serializable
-data class Owner(
+data class ComponentOwner(
     val name: String,
-    val ownedSize: OwnedSize,
+    val ownedSize: OwnedComponentSize,
 )

--- a/ruler-models/src/commonMain/kotlin/com/spotify/ruler/models/ComponentType.kt
+++ b/ruler-models/src/commonMain/kotlin/com/spotify/ruler/models/ComponentType.kt
@@ -17,7 +17,7 @@
 package com.spotify.ruler.models
 
 /** Type of an [AppComponent]. */
-enum class ComponentType {
-    INTERNAL,
-    EXTERNAL,
+enum class ComponentType(val label: String) {
+    INTERNAL("Internal"),
+    EXTERNAL("External"),
 }

--- a/ruler-models/src/commonMain/kotlin/com/spotify/ruler/models/DynamicFeature.kt
+++ b/ruler-models/src/commonMain/kotlin/com/spotify/ruler/models/DynamicFeature.kt
@@ -25,5 +25,5 @@ data class DynamicFeature(
     override val downloadSize: Long,
     override val installSize: Long,
     override val files: List<AppFile>,
-    override val owner: String? = null,
+    override val owner: Owner? = null,
 ) : FileContainer

--- a/ruler-models/src/commonMain/kotlin/com/spotify/ruler/models/DynamicFeature.kt
+++ b/ruler-models/src/commonMain/kotlin/com/spotify/ruler/models/DynamicFeature.kt
@@ -25,5 +25,5 @@ data class DynamicFeature(
     override val downloadSize: Long,
     override val installSize: Long,
     override val files: List<AppFile>,
-    override val owner: Owner? = null,
+    override val owner: ComponentOwner? = null,
 ) : FileContainer

--- a/ruler-models/src/commonMain/kotlin/com/spotify/ruler/models/FileContainer.kt
+++ b/ruler-models/src/commonMain/kotlin/com/spotify/ruler/models/FileContainer.kt
@@ -19,6 +19,6 @@ package com.spotify.ruler.models
 /** Piece of an app that can contain files. */
 interface FileContainer : Measurable {
     val name: String
-    val owner: String?
+    val owner: Owner?
     val files: List<AppFile>
 }

--- a/ruler-models/src/commonMain/kotlin/com/spotify/ruler/models/FileContainer.kt
+++ b/ruler-models/src/commonMain/kotlin/com/spotify/ruler/models/FileContainer.kt
@@ -19,6 +19,6 @@ package com.spotify.ruler.models
 /** Piece of an app that can contain files. */
 interface FileContainer : Measurable {
     val name: String
-    val owner: Owner?
+    val owner: ComponentOwner?
     val files: List<AppFile>
 }

--- a/ruler-models/src/commonMain/kotlin/com/spotify/ruler/models/FileType.kt
+++ b/ruler-models/src/commonMain/kotlin/com/spotify/ruler/models/FileType.kt
@@ -17,10 +17,10 @@
 package com.spotify.ruler.models
 
 /** Type of an [AppFile]. */
-enum class FileType {
-    CLASS,
-    RESOURCE,
-    ASSET,
-    NATIVE_LIB,
-    OTHER,
+enum class FileType(val label: String) {
+    CLASS("Classes"),
+    RESOURCE("Resources"),
+    ASSET("Assets"),
+    NATIVE_LIB("Native libraries"),
+    OTHER("Other"),
 }

--- a/ruler-models/src/commonMain/kotlin/com/spotify/ruler/models/Insights.kt
+++ b/ruler-models/src/commonMain/kotlin/com/spotify/ruler/models/Insights.kt
@@ -18,6 +18,7 @@ package com.spotify.ruler.models
 
 import kotlinx.serialization.Serializable
 
+/** Global Insights about the app size */
 @Serializable
 data class Insights(
     val appDownloadSize: Long,

--- a/ruler-models/src/commonMain/kotlin/com/spotify/ruler/models/Insights.kt
+++ b/ruler-models/src/commonMain/kotlin/com/spotify/ruler/models/Insights.kt
@@ -16,12 +16,13 @@
 
 package com.spotify.ruler.models
 
-/** Resource type for [FileType.RESOURCE]. */
-enum class ResourceType(val label: String) {
-    DRAWABLE("Drawable"),
-    LAYOUT("Layout"),
-    RAW("Raw"),
-    VALUES("Values"),
-    FONT("Font"),
-    OTHER("Other"),
-}
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class Insights(
+    val appDownloadSize: Long,
+    val appInstallSize: Long,
+    val fileTypeInsights: Map<FileType, TypeInsights>,
+    val resourcesTypeInsights: Map<ResourceType, TypeInsights>,
+    val componentTypeInsights: Map<ComponentType, TypeInsights>,
+)

--- a/ruler-models/src/commonMain/kotlin/com/spotify/ruler/models/Measurable.kt
+++ b/ruler-models/src/commonMain/kotlin/com/spotify/ruler/models/Measurable.kt
@@ -33,7 +33,4 @@ interface Measurable {
         SizeType.DOWNLOAD -> downloadSize
         SizeType.INSTALL -> installSize
     }
-
-    /** A mutable [Measurable] implementation. */
-    data class Mutable(override var downloadSize: Long, override var installSize: Long) : Measurable
 }

--- a/ruler-models/src/commonMain/kotlin/com/spotify/ruler/models/OwnedComponentSize.kt
+++ b/ruler-models/src/commonMain/kotlin/com/spotify/ruler/models/OwnedComponentSize.kt
@@ -18,8 +18,9 @@ package com.spotify.ruler.models
 
 import kotlinx.serialization.Serializable
 
+/** Total size of a component that belongs to a specific owner */
 @Serializable
-data class OwnedSize(
+data class OwnedComponentSize(
     override val downloadSize: Long,
     override val installSize: Long
 ) : Measurable

--- a/ruler-models/src/commonMain/kotlin/com/spotify/ruler/models/OwnedSize.kt
+++ b/ruler-models/src/commonMain/kotlin/com/spotify/ruler/models/OwnedSize.kt
@@ -18,14 +18,8 @@ package com.spotify.ruler.models
 
 import kotlinx.serialization.Serializable
 
-/** Analysis report of an app. */
 @Serializable
-data class AppReport(
-    val name: String,
-    val version: String,
-    val variant: String,
-    val components: List<AppComponent>,
-    val dynamicFeatures: List<DynamicFeature>,
-    val insights: Insights,
-    val ownershipOverview: Map<String, OwnershipOverview>?,
-)
+data class OwnedSize(
+    override val downloadSize: Long,
+    override val installSize: Long
+) : Measurable

--- a/ruler-models/src/commonMain/kotlin/com/spotify/ruler/models/Owner.kt
+++ b/ruler-models/src/commonMain/kotlin/com/spotify/ruler/models/Owner.kt
@@ -18,14 +18,8 @@ package com.spotify.ruler.models
 
 import kotlinx.serialization.Serializable
 
-/** Analysis report of an app. */
 @Serializable
-data class AppReport(
+data class Owner(
     val name: String,
-    val version: String,
-    val variant: String,
-    val components: List<AppComponent>,
-    val dynamicFeatures: List<DynamicFeature>,
-    val insights: Insights,
-    val ownershipOverview: Map<String, OwnershipOverview>?,
+    val ownedSize: OwnedSize,
 )

--- a/ruler-models/src/commonMain/kotlin/com/spotify/ruler/models/OwnershipOverview.kt
+++ b/ruler-models/src/commonMain/kotlin/com/spotify/ruler/models/OwnershipOverview.kt
@@ -21,6 +21,15 @@ import kotlinx.serialization.Serializable
 /** Overview with global size details obout the components/files owned by some owner */
 @Serializable
 data class OwnershipOverview(
+    val totalDownloadSize: Long,
+    val totalInstallSize: Long,
+    val filesCount: Long,
+    val filesFromNotOwnedComponentsDownloadSize: Long,
+    val filesFromNotOwnedComponentsInstallSize: Long,
+)
+
+/** Helper and mutable class used in intermediate calculation of OwnershipOverview */
+data class MutableOwnershipOverview(
     var totalDownloadSize: Long,
     var totalInstallSize: Long,
     var filesCount: Long,

--- a/ruler-models/src/commonMain/kotlin/com/spotify/ruler/models/OwnershipOverview.kt
+++ b/ruler-models/src/commonMain/kotlin/com/spotify/ruler/models/OwnershipOverview.kt
@@ -18,14 +18,11 @@ package com.spotify.ruler.models
 
 import kotlinx.serialization.Serializable
 
-/** Analysis report of an app. */
 @Serializable
-data class AppReport(
-    val name: String,
-    val version: String,
-    val variant: String,
-    val components: List<AppComponent>,
-    val dynamicFeatures: List<DynamicFeature>,
-    val insights: Insights,
-    val ownershipOverview: Map<String, OwnershipOverview>?,
+data class OwnershipOverview(
+    var totalDownloadSize: Long,
+    var totalInstallSize: Long,
+    var filesCount: Long,
+    var filesFromNotOwnedComponentsDownloadSize: Long,
+    var filesFromNotOwnedComponentsInstallSize: Long,
 )

--- a/ruler-models/src/commonMain/kotlin/com/spotify/ruler/models/OwnershipOverview.kt
+++ b/ruler-models/src/commonMain/kotlin/com/spotify/ruler/models/OwnershipOverview.kt
@@ -18,6 +18,7 @@ package com.spotify.ruler.models
 
 import kotlinx.serialization.Serializable
 
+/** Overview with global size details obout the components/files owned by some owner */
 @Serializable
 data class OwnershipOverview(
     var totalDownloadSize: Long,

--- a/ruler-models/src/commonMain/kotlin/com/spotify/ruler/models/TypeInsights.kt
+++ b/ruler-models/src/commonMain/kotlin/com/spotify/ruler/models/TypeInsights.kt
@@ -16,12 +16,17 @@
 
 package com.spotify.ruler.models
 
-/** Resource type for [FileType.RESOURCE]. */
-enum class ResourceType(val label: String) {
-    DRAWABLE("Drawable"),
-    LAYOUT("Layout"),
-    RAW("Raw"),
-    VALUES("Values"),
-    FONT("Font"),
-    OTHER("Other"),
-}
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class TypeInsights(
+    val downloadSize: Long,
+    val installSize: Long,
+    val count: Long,
+)
+
+data class MutableTypeInsights(
+    var downloadSize: Long,
+    var installSize: Long,
+    var count: Long,
+)

--- a/ruler-models/src/commonMain/kotlin/com/spotify/ruler/models/TypeInsights.kt
+++ b/ruler-models/src/commonMain/kotlin/com/spotify/ruler/models/TypeInsights.kt
@@ -18,6 +18,7 @@ package com.spotify.ruler.models
 
 import kotlinx.serialization.Serializable
 
+/** Insights about some type of measurable item (e.g: a file) */
 @Serializable
 data class TypeInsights(
     val downloadSize: Long,
@@ -25,6 +26,7 @@ data class TypeInsights(
     val count: Long,
 )
 
+/** Helper and mutable class used in intermediate calculation of TypeInsights */
 data class MutableTypeInsights(
     var downloadSize: Long,
     var installSize: Long,


### PR DESCRIPTION
### What has changed
Possibility to exclude the list of files of each component or dynamic feature in order to decrease the size of the report (both HTML and JSON).

The PR is not small so I will try to explain how I did it:
- Decouple the calculus of insights and ownership from the frontend and let the JsonReporter to recalculate that data, that way, the data will remain the same even if we do not pass any list of files. I have done that in two main commits:
    - 8f3492a42befadaa72e6ef314d7a1b52c8bee0ed: Calculate insights before rendering
    - 6ce88b3e641a2eeaaeffa72237599fd3f57f75c9: Calculate ownership before rendering
- Add a new property in the `RulerExtension` class (`false` by default) to expose a way to exclude files when desired. Done in fbe92f7b4d6210476a299a35c9551b9d9e447dcd
- Update UI so we don’t show an expandable row if there are no files to show. Done in d08998c8ee8d9a277c28cb3d1c17f9ce2407f271

Files exclusion would be configured like this:

```
ruler {
    // … other ruler configuration.
    shouldExcludeFileListing.set(true) // false by default
}

```

### Why was it changed
There are a couple of open issues at the time this PR is being opened regarding the size of the report. Maybe we could try to improve the generation of the Javascript and HTML code but it would be a small optimization since the main reason behind this problem seems to be the huge amount of files that belongs to the application components.

Removing that file listing entirely is not an option because it is a very useful information if we are looking for a file that may be heavily increasing our app size.

The solution to that problem that I’m proposing here is to give the developers the chance to ignore that files if they are struggling with report size on their CI machines (for example). The data reported (overview, breakdown, charts, etc) is not affected by this exclusion, the only difference when enabling this option is that it won’t be possible to expand a component and see its files.

In case some report without files shows some unexpected download/install size for a component or the whole app, a new execution of the task without this flag would be enough to have the complete report.

I have tested my proposal in a project with 286 components and the report has been reduced from 15.6MB down to 2.1MB.

Next steps: If you think this is something that makes sense, an iteration would be to allow a whitelist of components whose files won't be excluded.

I hope you find this useful :)

### Related issues

https://github.com/spotify/ruler/issues/96
https://github.com/spotify/ruler/issues/74 (this specific issue is not directly related with file size but with this new optional config, performance is improved as well)
