### PR TITLE
Fix analysis on AGP 8 with pure-JVM modules

### DIFF
--- a/ruler-common/src/main/java/com/spotify/ruler/common/dependency/ArtifactParser.kt
+++ b/ruler-common/src/main/java/com/spotify/ruler/common/dependency/ArtifactParser.kt
@@ -34,6 +34,15 @@ class DefaultArtifactParser : ArtifactParser<ArtifactResult.DefaultArtifact> {
     }
 }
 
+/** Artifact parser for .class files that returns a list of the class artifact. */
+class ClassArtifactParser : ArtifactParser<ArtifactResult.ClassArtifact> {
+    override fun parseFile(artifact: ArtifactResult.ClassArtifact): List<DependencyEntry> {
+        val name =
+            artifact.file.absolutePath.removePrefix(artifact.resolvedArtifactFile.absolutePath)
+        return listOf(DependencyEntry.Class(name, artifact.component))
+    }
+}
+
 /** Artifact parser which parses JAR artifacts and returns the contents of those JAR files. */
 class JarArtifactParser : ArtifactParser<ArtifactResult.JarArtifact> {
 
@@ -62,4 +71,6 @@ sealed interface ArtifactResult {
     ) : ArtifactResult
 
     data class JarArtifact(val file: File, val component: String) : ArtifactResult
+
+    data class ClassArtifact(val file: File, val resolvedArtifactFile: File, val component: String) : ArtifactResult
 }

--- a/ruler-common/src/main/java/com/spotify/ruler/common/dependency/DependencyParser.kt
+++ b/ruler-common/src/main/java/com/spotify/ruler/common/dependency/DependencyParser.kt
@@ -25,10 +25,14 @@ class DependencyParser {
 
         val jarArtifactParser = JarArtifactParser()
         val defaultArtifactParser = DefaultArtifactParser()
+        val classArtifactParser = ClassArtifactParser()
         entries.forEach {
             result += when (it) {
                 is ArtifactResult.DefaultArtifact -> {
                     defaultArtifactParser.parseFile(it)
+                }
+                is ArtifactResult.ClassArtifact -> {
+                    classArtifactParser.parseFile(it)
                 }
                 is ArtifactResult.JarArtifact -> {
                     jarArtifactParser.parseFile(it)


### PR DESCRIPTION
### What has changed
Add support for bare .class files (not in jar files) in the release classpath.

### Why was it changed
In AGP8, the 'android-classes' variant of the runtime classpath includes plain `.class` files. The javadoc in `AndroidArtifacts` says as much: "A jar or directory containing classes." When you have pure-JVM .jar dependencies, these turn into plain class files in your runtime classpath (for reasons I do not yet understand).

### Related issues
https://github.com/spotify/ruler/issues/116
