### PR TITLE
Expose ruler-common as an API intead od implementation

### DIFF
--- a/ruler-gradle-plugin/build.gradle.kts
+++ b/ruler-gradle-plugin/build.gradle.kts
@@ -42,7 +42,7 @@ dependencies {
     compileOnly(Dependencies.DEXLIB)
 
     implementation(project(":ruler-models"))
-    implementation(project(":ruler-common"))
+    api(project(":ruler-common"))
 
     implementation(Dependencies.APK_ANALYZER) {
         exclude(group = "com.android.tools.lint") // Avoid leaking incompatible Lint versions to consumers


### PR DESCRIPTION
### What has changed
Change the dependency of ruler common in Ruler plugin from implementation to api.

### Why was it changed
This is required in order to upgrade to the v2 of Ruler with the new dependency of ruler-common module.

