### PR TITLE
Add the option to pass Bloaty path to RulerCli

### DIFF
--- a/ruler-cli/src/main/java/com/spotify/ruler/cli/RulerCli.kt
+++ b/ruler-cli/src/main/java/com/spotify/ruler/cli/RulerCli.kt
@@ -53,6 +53,7 @@ class RulerCli : CliktCommand(), BaseRulerTask {
     private val resourceMappingFile: File? by option().file()
     private val unstrippedNativeFiles: List<File> by option().file().multiple()
     private val aapt2Tool: File? by option().file()
+    private val bloatyTool: File? by option().file()
 
     override fun print(content: String) = echo(content)
 
@@ -62,6 +63,7 @@ class RulerCli : CliktCommand(), BaseRulerTask {
 
     override fun rulerConfig(): RulerConfig = config
     override fun provideUnstrippedLibraryFiles() = unstrippedNativeFiles
+    override fun provideBloatyPath() = bloatyTool?.path
 
     private val config: RulerConfig by lazy {
         val json = Json.decodeFromStream<JsonRulerConfig>(rulerConfigJson.inputStream())
@@ -115,6 +117,7 @@ class RulerCli : CliktCommand(), BaseRulerTask {
         Using Proguard Mapping File: ${mappingFile?.path}
         Using Resource Mapping File: ${resourceMappingFile?.path}
         Using AAPT2: ${aapt2Tool?.path}
+        Using Bloaty: ${bloatyTool?.path}
         Writing reports to: ${reportDir.path}
         """.trimIndent())
         super.run()

--- a/ruler-common/src/main/java/com/spotify/ruler/common/BaseRulerTask.kt
+++ b/ruler-common/src/main/java/com/spotify/ruler/common/BaseRulerTask.kt
@@ -45,6 +45,8 @@ interface BaseRulerTask {
     fun provideResourceMappingFile(): File?
     fun rulerConfig(): RulerConfig
     fun provideUnstrippedLibraryFiles(): List<File>
+    fun provideBloatyPath(): String?
+
     private val rulerConfig: RulerConfig
         get() = rulerConfig()
 
@@ -85,7 +87,7 @@ interface BaseRulerTask {
     }
 
     private fun getFilesFromBundle(): Map<String, List<AppFile>> {
-        val apkParser = ApkParser(provideUnstrippedLibraryFiles())
+        val apkParser = ApkParser(provideUnstrippedLibraryFiles(), provideBloatyPath())
         val classNameSanitizer = ClassNameSanitizer(provideMappingFile())
         val resourceNameSanitizer = ResourceNameSanitizer(provideResourceMappingFile())
         val apkSanitizer = ApkSanitizer(classNameSanitizer, resourceNameSanitizer)

--- a/ruler-common/src/main/java/com/spotify/ruler/common/apk/ApkParser.kt
+++ b/ruler-common/src/main/java/com/spotify/ruler/common/apk/ApkParser.kt
@@ -24,7 +24,8 @@ import java.util.zip.ZipFile
 
 /** Responsible for parsing and extracting entries from APK files. */
 class ApkParser(
-    private val unstrippedNativeLibraryPaths: List<File> = emptyList()
+    private val unstrippedNativeLibraryPaths: List<File> = emptyList(),
+    private val bloatyPath: String? = null
 ) {
 
     /** Parses and returns the list of entries contained in the given [apkFile]. */
@@ -33,7 +34,7 @@ class ApkParser(
         val sizeCalculator = ApkSizeCalculator.getDefault()
         val downloadSizePerFile = sizeCalculator.getDownloadSizePerFile(apkFile.toPath())
         val installSizePerFile = sizeCalculator.getRawSizePerFile(apkFile.toPath())
-
+        val bloaty = Bloaty(bloatyPath)
         val apkEntries = mutableListOf<ApkEntry>()
         ZipFile(apkFile).use { zipFile ->
             zipFile.entries().iterator().forEach { zipEntry ->
@@ -52,7 +53,7 @@ class ApkParser(
                             name,
                             downloadSize,
                             installSize,
-                            Bloaty.parseNativeLibraryEntry(
+                            bloaty.parseNativeLibraryEntry(
                                 bytes,
                                 debugFileForNativeLibrary(entryName = name)
                             )

--- a/ruler-common/src/main/java/com/spotify/ruler/common/bloaty/Bloaty.kt
+++ b/ruler-common/src/main/java/com/spotify/ruler/common/bloaty/Bloaty.kt
@@ -16,12 +16,12 @@ private const val COLUMN_SIZE = 3
  *
  * Bloaty Source Code Repository: [https://github.com/google/bloaty](https://github.com/google/bloaty)
  */
-object Bloaty {
+class Bloaty(val path: String? = null) {
 
     private val bloatyPath: String? by lazy { findBloatyPath() }
 
     private fun findBloatyPath(): String? {
-        val path = executeCommandAndGetOutput("which bloaty").singleOrNull()
+        val path = path ?: executeCommandAndGetOutput("which bloaty").singleOrNull()
         return if (path.isNullOrEmpty()) {
             println("Could not find Bloaty. Install Bloaty for more information about native libraries.")
             null

--- a/ruler-gradle-plugin/src/main/kotlin/com/spotify/ruler/plugin/RulerTask.kt
+++ b/ruler-gradle-plugin/src/main/kotlin/com/spotify/ruler/plugin/RulerTask.kt
@@ -118,6 +118,9 @@ abstract class RulerTask : DefaultTask(), BaseRulerTask {
     override fun provideUnstrippedLibraryFiles(): List<File> = unstrippedNativeFiles.get().map {
         it.asFile
     }
+
+    override fun provideBloatyPath() = null
+
     private fun createApkFile(): Map<String, List<File>> {
         val apkCreator = ApkCreator(project.rootDir)
 


### PR DESCRIPTION
### What has changed
Add the possibility to pass an optional --bloatytool parameter to RulerCli to explicitly set the the path of the Bloaty tool.

