### PR TITLE
Updating bundletool version to 1.15.6 to fix the install size issue

### DIFF
--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -65,7 +65,7 @@ object Dependencies {
         const val NEXUS_PUBLISH_GRADLE_PLUGIN = "1.1.0" // https://mvnrepository.com/artifact/io.github.gradle-nexus.publish-plugin/io.github.gradle-nexus.publish-plugin.gradle.plugin
         const val SHADOW_GRADLE_PLUGIN = "7.1.2" // https://plugins.gradle.org/plugin/com.github.johnrengelman.shadow
 
-        const val BUNDLETOOL = "1.11.0" // https://mvnrepository.com/artifact/com.android.tools.build/bundletool
+        const val BUNDLETOOL = "1.15.6" // https://mvnrepository.com/artifact/com.android.tools.build/bundletool
         const val PROTOBUF = "3.21.6" // https://mvnrepository.com/artifact/com.google.protobuf/protobuf-java
         const val DEXLIB = "2.5.2" // https://mvnrepository.com/artifact/org.smali/dexlib2
 


### PR DESCRIPTION
### What has changed
<!-- A concise description of the changes contained in this pull request. -->
With current version of bundletool it is including only the base-master or base-variant(arm64).apk size. 
Bundletool has fixed the issue now and it gives the correct install size.

### Why was it changed
<!-- A concise description of why these changes are being proposed. -->


### Related issues
<!-- Links to any related issues, if there are some. -->

