### PR TITLE
Fixed `AGP 8.3.0` breaking change

### DIFF
--- a/ruler-cli/src/main/java/com/spotify/ruler/cli/RulerCli.kt
+++ b/ruler-cli/src/main/java/com/spotify/ruler/cli/RulerCli.kt
@@ -150,7 +150,7 @@ class RulerCli : CliktCommand(), BaseRulerTask {
                     )
                     InjectedToolApkCreator(aapt2Tool!!.toPath())
                 } else {
-                    ApkCreator(File(projectPath))
+                    ApkCreator()
                 }
             ) {
                 createSplitApks(

--- a/ruler-common/build.gradle.kts
+++ b/ruler-common/build.gradle.kts
@@ -38,7 +38,9 @@ val browserDist by configurations.creating {
 }
 
 dependencies {
-    implementation(Dependencies.ANDROID_GRADLE_PLUGIN)
+    compileOnly(Dependencies.ANDROID_GRADLE_PLUGIN)
+    testRuntimeOnly(Dependencies.ANDROID_GRADLE_PLUGIN)
+
     compileOnly(Dependencies.BUNDLETOOL)
     compileOnly(Dependencies.PROTOBUF_CORE)
     compileOnly(Dependencies.ANDROID_TOOLS_COMMON)

--- a/ruler-common/src/test/kotlin/com/spotify/ruler/common/apk/ApkCreatorTest.kt
+++ b/ruler-common/src/test/kotlin/com/spotify/ruler/common/apk/ApkCreatorTest.kt
@@ -24,7 +24,7 @@ import java.io.File
 import java.nio.file.Paths
 
 class ApkCreatorTest {
-    private val creator = ApkCreator(File(""))
+    private val creator = ApkCreator()
     private val bundleFile = Paths.get("src", "test", "resources", "test.aab").toFile()
     private val deviceSpec = DeviceSpec("arm64-v8a", "en", 480, 27)
 

--- a/ruler-gradle-plugin/src/main/kotlin/com/spotify/ruler/plugin/RulerTask.kt
+++ b/ruler-gradle-plugin/src/main/kotlin/com/spotify/ruler/plugin/RulerTask.kt
@@ -16,6 +16,7 @@
 
 package com.spotify.ruler.plugin
 
+import com.android.build.gradle.BaseExtension
 import com.spotify.ruler.common.BaseRulerTask
 import com.spotify.ruler.common.apk.ApkCreator
 import com.spotify.ruler.common.dependency.DependencyComponent
@@ -124,7 +125,8 @@ abstract class RulerTask : DefaultTask(), BaseRulerTask {
     override fun provideBloatyPath() = null
 
     private fun createApkFile(): Map<String, List<File>> {
-        val apkCreator = ApkCreator(project.rootDir)
+        val android = project.extensions.findByName("android") as BaseExtension?
+        val apkCreator = ApkCreator(android?.sdkDirectory)
 
         val apkFile = bundleFile.asFile.get()
         return if (apkFile.extension == "apk") {


### PR DESCRIPTION
### What has changed
Addresses #153 with a minimal set of changes to unblock the consumers of this plugin.

The breaking change is produced because the plugin is accessing an internal AGP API for getting the Android SDK location.

As suggested by @SimonMarquis, this can be done with a public API in `BaseExtension.sdkDirectory `. I made minimal changes to read from there, falling back to an `ANDROID_HOME` environment variable if not provided to keep the coupling at the bare minimum.

Additionally, I've moved the whole `ANDROID_GRADLE_PLUGIN` dependency as a `compileOnly` to avoid leaking it to the consumers

### Why was it changed
Because since `AGP 8.3.0`, the internal API signature has changed, and it breaks: #153

### Related issues
AGP 8.3.0 fails with NoSuchMethodError #153

> [!NOTE]
> This project is a bit outdated on its dependencies:
> A bump to `8.3.0` was not possible without also bumping `Gradle` to at least `8.4`, and doing so introduced a new problem with accessing a removed API
> ```
> > An exception occurred applying plugin request [id: 'com.guardsquare.proguard']
> > Failed to apply plugin 'com.guardsquare.proguard'.
>    > API 'android.registerTransform' is removed.
> ```

