### PR TITLE
Support verification of download and install size

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,20 @@ ruler {
 }
 ```
 
+#### Verification
+
+Optionally, you can also configure Ruler to verify that your application size is under a given
+threshold.
+
+```kotlin
+ruler {
+    verification {
+        downloadSizeThreshold = 2 * 1024 * 1024 // 2 MB in bytes
+        installSizeThreshold = 2 * 1024 * 1024 // 2 MB in bytes
+    }
+}
+```
+
 ### Running the task
 
 Once this is done, `analyze<VariantName>Bundle` tasks will be added for each of your app variants. Running this task will build the app and generate a HTML report, which you can use to analyze your app size. It will also generate a JSON report, in case you want to further process the data.

--- a/ruler-cli/src/main/java/com/spotify/ruler/cli/RulerCli.kt
+++ b/ruler-cli/src/main/java/com/spotify/ruler/cli/RulerCli.kt
@@ -100,7 +100,8 @@ class RulerCli : CliktCommand(), BaseRulerTask {
             defaultOwner = defaultOwner,
             omitFileBreakdown = omitFileBreakdown,
             additionalEntries = additionalEntries,
-            ignoredFiles = ignoreFile
+            ignoredFiles = ignoreFile,
+            verificationConfig = null
         )
     }
 

--- a/ruler-common/src/main/java/com/spotify/ruler/common/BaseRulerTask.kt
+++ b/ruler-common/src/main/java/com/spotify/ruler/common/BaseRulerTask.kt
@@ -86,8 +86,8 @@ interface BaseRulerTask {
         val ownershipInfo = getOwnershipInfo() // Get ownership information for all components
         generateReports(components, featureFiles, ownershipInfo)
 
-        val verificator = rulerConfig.verificationConfig?.let(::Verificator)
-        verificator?.verify(components.values.flatten())
+        val verificator = rulerConfig.verificationConfig.let(::Verificator)
+        verificator.verify(components.values.flatten())
     }
 
     private fun getFilesFromBundle(): Map<String, List<AppFile>> {

--- a/ruler-common/src/main/java/com/spotify/ruler/common/BaseRulerTask.kt
+++ b/ruler-common/src/main/java/com/spotify/ruler/common/BaseRulerTask.kt
@@ -29,6 +29,7 @@ import com.spotify.ruler.common.report.JsonReporter
 import com.spotify.ruler.common.sanitizer.ClassNameSanitizer
 import com.spotify.ruler.common.sanitizer.ResourceNameSanitizer
 import com.spotify.ruler.common.util.toEscapeCharRegex
+import com.spotify.ruler.common.veritication.Verificator
 import com.spotify.ruler.models.AppFile
 import com.spotify.ruler.models.ComponentType
 import kotlinx.serialization.decodeFromString
@@ -84,6 +85,9 @@ interface BaseRulerTask {
 
         val ownershipInfo = getOwnershipInfo() // Get ownership information for all components
         generateReports(components, featureFiles, ownershipInfo)
+
+        val verificator = rulerConfig.verificationConfig?.let(::Verificator)
+        verificator?.verify(components.values.flatten())
     }
 
     private fun getFilesFromBundle(): Map<String, List<AppFile>> {

--- a/ruler-common/src/main/java/com/spotify/ruler/common/models/RulerConfig.kt
+++ b/ruler-common/src/main/java/com/spotify/ruler/common/models/RulerConfig.kt
@@ -32,5 +32,5 @@ data class RulerConfig(
     val omitFileBreakdown: Boolean,
     val additionalEntries: List<ApkEntry.Default>?,
     val ignoredFiles: List<String>,
-    val verificationConfig: VerificationConfig?
+    val verificationConfig: VerificationConfig
 )

--- a/ruler-common/src/main/java/com/spotify/ruler/common/models/RulerConfig.kt
+++ b/ruler-common/src/main/java/com/spotify/ruler/common/models/RulerConfig.kt
@@ -17,6 +17,7 @@
 package com.spotify.ruler.common.models
 
 import com.spotify.ruler.common.apk.ApkEntry
+import com.spotify.ruler.common.veritication.VerificationConfig
 import java.io.File
 
 data class RulerConfig(
@@ -30,5 +31,6 @@ data class RulerConfig(
     val defaultOwner: String,
     val omitFileBreakdown: Boolean,
     val additionalEntries: List<ApkEntry.Default>?,
-    val ignoredFiles: List<String>
+    val ignoredFiles: List<String>,
+    val verificationConfig: VerificationConfig?
 )

--- a/ruler-common/src/main/java/com/spotify/ruler/common/veritication/SizeExceededException.kt
+++ b/ruler-common/src/main/java/com/spotify/ruler/common/veritication/SizeExceededException.kt
@@ -16,5 +16,5 @@
 
 package com.spotify.ruler.common.veritication
 
-class VerificationException(label: String, size: Long, threshold: Long) :
+class SizeExceededException(label: String, size: Long, threshold: Long) :
     Exception("$label size exceeds the threshold by ${size - threshold} bytes.")

--- a/ruler-common/src/main/java/com/spotify/ruler/common/veritication/VerificationConfig.kt
+++ b/ruler-common/src/main/java/com/spotify/ruler/common/veritication/VerificationConfig.kt
@@ -1,0 +1,22 @@
+/*
+* Copyright 2024 Spotify AB
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+package com.spotify.ruler.common.veritication
+
+data class VerificationConfig(
+    val downloadSizeThreshold: Long = Long.MAX_VALUE,
+    val installSizeThreshold: Long = Long.MAX_VALUE
+)

--- a/ruler-common/src/main/java/com/spotify/ruler/common/veritication/VerificationException.kt
+++ b/ruler-common/src/main/java/com/spotify/ruler/common/veritication/VerificationException.kt
@@ -1,0 +1,20 @@
+/*
+* Copyright 2024 Spotify AB
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+package com.spotify.ruler.common.veritication
+
+class VerificationException(label: String, size: Long, threshold: Long) :
+    Exception("$label size exceeds the threshold by ${size - threshold} bytes.")

--- a/ruler-common/src/main/java/com/spotify/ruler/common/veritication/Verificator.kt
+++ b/ruler-common/src/main/java/com/spotify/ruler/common/veritication/Verificator.kt
@@ -24,13 +24,13 @@ class Verificator(private val config: VerificationConfig) {
         val downloadSize = components.sumOf(AppFile::downloadSize)
         val downloadSizeThreshold = config.downloadSizeThreshold
         if (downloadSize > downloadSizeThreshold) {
-            throw VerificationException("Download", downloadSize, downloadSizeThreshold)
+            throw SizeExceededException("Download", downloadSize, downloadSizeThreshold)
         }
 
         val installSize = components.sumOf(AppFile::installSize)
         val installSizeThreshold = config.installSizeThreshold
         if (installSize > installSizeThreshold) {
-            throw VerificationException("Install", installSize, installSizeThreshold)
+            throw SizeExceededException("Install", installSize, installSizeThreshold)
         }
     }
 }

--- a/ruler-common/src/main/java/com/spotify/ruler/common/veritication/Verificator.kt
+++ b/ruler-common/src/main/java/com/spotify/ruler/common/veritication/Verificator.kt
@@ -1,0 +1,36 @@
+/*
+* Copyright 2024 Spotify AB
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+package com.spotify.ruler.common.veritication
+
+import com.spotify.ruler.models.AppFile
+
+class Verificator(private val config: VerificationConfig) {
+
+    fun verify(components: List<AppFile>) {
+        val downloadSize = components.sumOf(AppFile::downloadSize)
+        val downloadSizeThreshold = config.downloadSizeThreshold
+        if (downloadSize > downloadSizeThreshold) {
+            throw VerificationException("Download", downloadSize, downloadSizeThreshold)
+        }
+
+        val installSize = components.sumOf(AppFile::installSize)
+        val installSizeThreshold = config.installSizeThreshold
+        if (installSize > installSizeThreshold) {
+            throw VerificationException("Install", installSize, installSizeThreshold)
+        }
+    }
+}

--- a/ruler-common/src/test/kotlin/com/spotify/ruler/common/verificator/VerificatorTest.kt
+++ b/ruler-common/src/test/kotlin/com/spotify/ruler/common/verificator/VerificatorTest.kt
@@ -1,0 +1,87 @@
+/*
+* Copyright 2024 Spotify AB
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+package com.spotify.ruler.common.verificator
+
+import com.spotify.ruler.common.veritication.VerificationConfig
+import com.spotify.ruler.common.veritication.VerificationException
+import com.spotify.ruler.common.veritication.Verificator
+import com.spotify.ruler.models.AppFile
+import com.spotify.ruler.models.FileType
+import com.spotify.ruler.models.ResourceType
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertDoesNotThrow
+import org.junit.jupiter.api.assertThrows
+
+class VerificatorTest {
+    private val config = VerificationConfig(100, 100)
+    private val verificator = Verificator(config)
+
+    @Test
+    fun `Download size under threshold does not trigger VerificationException`() {
+        val downloadSize = config.downloadSizeThreshold / 2
+        val appFiles = generateAppFiles(downloadSize)
+
+        assertDoesNotThrow { verificator.verify(appFiles) }
+    }
+
+    @Test
+    fun `Download size exceeding threshold triggers VerificationException`() {
+        val downloadSize = config.downloadSizeThreshold * 2
+        val appFiles = generateAppFiles(downloadSize)
+
+        assertThrows<VerificationException> { verificator.verify(appFiles) }
+    }
+
+    @Test
+    fun `Install size under threshold does not trigger VerificationException`() {
+        val installSize = config.installSizeThreshold / 2
+        val appFiles = generateAppFiles(config.downloadSizeThreshold, installSize)
+
+        assertDoesNotThrow { verificator.verify(appFiles) }
+    }
+
+    @Test
+    fun `Install size exceeding threshold triggers VerificationException`() {
+        val installSize = config.downloadSizeThreshold * 2
+        val appFiles = generateAppFiles(config.downloadSizeThreshold, installSize)
+
+        assertThrows<VerificationException> { verificator.verify(appFiles) }
+    }
+
+    private fun generateAppFiles(
+        downloadSize: Long,
+        installSize: Long = downloadSize
+    ): List<AppFile> {
+        val downloadSizePerFile = downloadSize / 2
+        val installSizePerFile = installSize / 2
+        return listOf(
+            AppFile(
+                "com.spotify.MainActivity",
+                FileType.CLASS,
+                downloadSizePerFile,
+                installSizePerFile
+            ),
+            AppFile(
+                "/res/layout/activity_main.xml",
+                FileType.RESOURCE,
+                downloadSizePerFile,
+                installSizePerFile,
+                resourceType = ResourceType.LAYOUT
+            ),
+        )
+    }
+}

--- a/ruler-common/src/test/kotlin/com/spotify/ruler/common/verificator/VerificatorTest.kt
+++ b/ruler-common/src/test/kotlin/com/spotify/ruler/common/verificator/VerificatorTest.kt
@@ -16,8 +16,8 @@
 
 package com.spotify.ruler.common.verificator
 
+import com.spotify.ruler.common.veritication.SizeExceededException
 import com.spotify.ruler.common.veritication.VerificationConfig
-import com.spotify.ruler.common.veritication.VerificationException
 import com.spotify.ruler.common.veritication.Verificator
 import com.spotify.ruler.models.AppFile
 import com.spotify.ruler.models.FileType
@@ -31,7 +31,7 @@ class VerificatorTest {
     private val verificator = Verificator(config)
 
     @Test
-    fun `Download size under threshold does not trigger VerificationException`() {
+    fun `Download size under threshold does not trigger SizeExceededException`() {
         val downloadSize = config.downloadSizeThreshold / 2
         val appFiles = generateAppFiles(downloadSize)
 
@@ -39,15 +39,15 @@ class VerificatorTest {
     }
 
     @Test
-    fun `Download size exceeding threshold triggers VerificationException`() {
+    fun `Download size exceeding threshold triggers SizeExceededException`() {
         val downloadSize = config.downloadSizeThreshold * 2
         val appFiles = generateAppFiles(downloadSize)
 
-        assertThrows<VerificationException> { verificator.verify(appFiles) }
+        assertThrows<SizeExceededException> { verificator.verify(appFiles) }
     }
 
     @Test
-    fun `Install size under threshold does not trigger VerificationException`() {
+    fun `Install size under threshold does not trigger SizeExceededException`() {
         val installSize = config.installSizeThreshold / 2
         val appFiles = generateAppFiles(config.downloadSizeThreshold, installSize)
 
@@ -55,11 +55,11 @@ class VerificatorTest {
     }
 
     @Test
-    fun `Install size exceeding threshold triggers VerificationException`() {
+    fun `Install size exceeding threshold triggers SizeExceededException`() {
         val installSize = config.downloadSizeThreshold * 2
         val appFiles = generateAppFiles(config.downloadSizeThreshold, installSize)
 
-        assertThrows<VerificationException> { verificator.verify(appFiles) }
+        assertThrows<SizeExceededException> { verificator.verify(appFiles) }
     }
 
     private fun generateAppFiles(

--- a/ruler-gradle-plugin/src/main/kotlin/com/spotify/ruler/plugin/RulerTask.kt
+++ b/ruler-gradle-plugin/src/main/kotlin/com/spotify/ruler/plugin/RulerTask.kt
@@ -25,6 +25,7 @@ import com.spotify.ruler.common.models.AppInfo
 import com.spotify.ruler.common.models.DeviceSpec
 import com.spotify.ruler.common.models.RulerConfig
 import com.spotify.ruler.common.sanitizer.ClassNameSanitizer
+import com.spotify.ruler.common.veritication.VerificationConfig
 import com.spotify.ruler.plugin.dependency.EntryParser
 import org.gradle.api.DefaultTask
 import org.gradle.api.file.DirectoryProperty
@@ -77,6 +78,9 @@ abstract class RulerTask : DefaultTask(), BaseRulerTask {
     @get:InputFile
     abstract val staticDependenciesFile: RegularFileProperty
 
+    @get:Input
+    abstract val verificationConfig: Property<VerificationConfig>
+
     @get:OutputDirectory
     abstract val workingDir: DirectoryProperty
 
@@ -101,7 +105,7 @@ abstract class RulerTask : DefaultTask(), BaseRulerTask {
             omitFileBreakdown = omitFileBreakdown.get(),
             additionalEntries = emptyList(),
             ignoredFiles = emptyList(),
-            verificationConfig = null
+            verificationConfig = verificationConfig.get()
         )
     }
 

--- a/ruler-gradle-plugin/src/main/kotlin/com/spotify/ruler/plugin/RulerTask.kt
+++ b/ruler-gradle-plugin/src/main/kotlin/com/spotify/ruler/plugin/RulerTask.kt
@@ -100,7 +100,8 @@ abstract class RulerTask : DefaultTask(), BaseRulerTask {
             defaultOwner = defaultOwner.get(),
             omitFileBreakdown = omitFileBreakdown.get(),
             additionalEntries = emptyList(),
-            ignoredFiles = emptyList()
+            ignoredFiles = emptyList(),
+            verificationConfig = null
         )
     }
 

--- a/ruler-gradle-plugin/src/main/kotlin/com/spotify/ruler/plugin/RulerVerificationExtension.kt
+++ b/ruler-gradle-plugin/src/main/kotlin/com/spotify/ruler/plugin/RulerVerificationExtension.kt
@@ -14,17 +14,17 @@
 * limitations under the License.
 */
 
-package com.spotify.ruler.common.veritication
+package com.spotify.ruler.plugin
 
-import java.io.Serializable
-import kotlinx.serialization.Serializable as KSerializable
+import org.gradle.api.model.ObjectFactory
+import org.gradle.api.provider.Property
 
-@KSerializable
-data class VerificationConfig(
-    val downloadSizeThreshold: Long = Long.MAX_VALUE,
-    val installSizeThreshold: Long = Long.MAX_VALUE
-) : Serializable {
-    companion object {
-        private const val serialVersionUID = 1L
+open class RulerVerificationExtension(objects: ObjectFactory) {
+    val downloadSizeThreshold: Property<Long> = objects.property(Long::class.java)
+    val installSizeThreshold: Property<Long> = objects.property(Long::class.java)
+
+    init {
+        downloadSizeThreshold.convention(Long.MAX_VALUE)
+        installSizeThreshold.convention(Long.MAX_VALUE)
     }
 }

--- a/ruler-gradle-plugin/src/test/kotlin/com/spotify/ruler/plugin/RulerIntegrationTest.kt
+++ b/ruler-gradle-plugin/src/test/kotlin/com/spotify/ruler/plugin/RulerIntegrationTest.kt
@@ -88,6 +88,30 @@ class RulerIntegrationTest {
         gradlew(task, expectFailure = true)
     }
 
+    @ParameterizedTest
+    @ValueSource(strings = [":app:analyzeDebugBundle", ":app:analyzeReleaseBundle"])
+    fun `Bundle analysis fails if the download size threshold is set and breached`(task: String) {
+        val buildGradle = projectDir.resolve("app/build.gradle")
+        buildGradle.writeText(
+            buildGradle.readText()
+                .substringBeforeLast("}") + "verification { downloadSizeThreshold = 100L } }"
+        )
+
+        gradlew(task, expectFailure = true)
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = [":app:analyzeDebugBundle", ":app:analyzeReleaseBundle"])
+    fun `Bundle analysis fails if the install size threshold is set and breached`(task: String) {
+        val buildGradle = projectDir.resolve("app/build.gradle")
+        buildGradle.writeText(
+            buildGradle.readText()
+                .substringBeforeLast("}") + "verification { installSizeThreshold = 100L } }"
+        )
+
+        gradlew(task, expectFailure = true)
+    }
+
     private fun gradlew(vararg arguments: String, expectFailure: Boolean = false): BuildResult {
          val runner = GradleRunner.create()
             .withProjectDir(projectDir)

--- a/sample/app/build.gradle.kts
+++ b/sample/app/build.gradle.kts
@@ -60,6 +60,11 @@ ruler {
 
     ownershipFile.set(project.layout.projectDirectory.file("ownership.yaml"))
     defaultOwner.set("default-team")
+
+    verification {
+        downloadSizeThreshold = 20 * 1000 * 1000
+        installSizeThreshold = 20 * 1000 * 1000
+    }
 }
 
 // Include Ruler tasks in checks


### PR DESCRIPTION
### What has changed

Ruler now supports verification of AAB download and install sizes against user-defined thresholds. This new feature allows developers to ensure their app bundles meet size requirements before deployment.
Example configuration:

```gradle
ruler {
    // Other configurations...
    verification {
        downloadSizeThreshold = 2 * 1024 * 1024 // 2 MB in bytes
        installSizeThreshold = 2 * 1024 * 1024 // 2 MB in bytes
    }
}
```

If the AAB exceeds either threshold during the `analyze<Variant>Bundle` task, Ruler will throw a `VerificationException`:

```
Execution failed for task ':sample:app:analyzeDebugBundle'.
> com.spotify.ruler.common.verification.VerificationException: Download size exceeds the threshold by 1107079 bytes.
```

### Why was it changed

If an end user requires such functionality, they would currently have to either implement a processor for Ruler's output files or depend on other tools (e.g., `apkanalyzer`). Having this built into Ruler would help centralize that logic, thus reducing potential duplication.