### PR TITLE
Bump actions/upload-artifact version

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -37,6 +37,6 @@ jobs:
       - name: Archive sample HTML report
         uses: actions/upload-artifact@v4
         with:
-          name: report
+          name: report_${{ matrix.os }}_${{ matrix.android-gradle-plugin }}
           path: sample/app/build/reports/ruler/release/report.html
           retention-days: 7

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -35,7 +35,7 @@ jobs:
         run: ./gradlew check --no-daemon --stacktrace "-Dorg.gradle.jvmargs=-Xmx2048m -XX:MaxMetaspaceSize=2048m"
 
       - name: Archive sample HTML report
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: report
           path: sample/app/build/reports/ruler/release/report.html


### PR DESCRIPTION
### What has changed
We now depend on `actions/upload-artifact@v4`.

### Why was it changed
`actions/upload-artifact@v1` and `v2` [have been deprecated following the release of `v4`](https://github.blog/changelog/2024-02-13-deprecation-notice-v1-and-v2-of-the-artifact-actions/). This is currently breaking CI workflows ([ref](https://github.com/spotify/ruler/actions/runs/10924478555/job/30323621597?pr=168)).