### PR TITLE
Change dependencies to impl

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath("com.spotify.ruler:ruler-gradle-plugin:2.0.0-beta-2")
+        classpath("com.spotify.ruler:ruler-gradle-plugin:2.0.0-beta-3")
     }
 }
 ```

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -63,8 +63,8 @@ object Dependencies {
         const val NEXUS_PUBLISH_GRADLE_PLUGIN = "2.0.0" // https://mvnrepository.com/artifact/io.github.gradle-nexus.publish-plugin/io.github.gradle-nexus.publish-plugin.gradle.plugin
         const val SHADOW_GRADLE_PLUGIN = "7.1.2" // https://plugins.gradle.org/plugin/com.github.johnrengelman.shadow
 
-        const val BUNDLETOOL = "1.15.6" // https://mvnrepository.com/artifact/com.android.tools.build/bundletool
-        const val PROTOBUF = "3.21.6" // https://mvnrepository.com/artifact/com.google.protobuf/protobuf-java
+        const val BUNDLETOOL = "1.17.2" // https://mvnrepository.com/artifact/com.android.tools.build/bundletool
+        const val PROTOBUF = "3.22.3" // https://mvnrepository.com/artifact/com.google.protobuf/protobuf-java
         const val DEXLIB = "2.5.2" // https://mvnrepository.com/artifact/org.smali/dexlib2
 
         const val ANDROID_TOOLS = "30.0.4" // https://mvnrepository.com/artifact/com.android.tools/common?repo=google

--- a/buildSrc/src/main/kotlin/Publish.kt
+++ b/buildSrc/src/main/kotlin/Publish.kt
@@ -23,7 +23,7 @@ import org.gradle.kotlin.dsl.extra
 import org.gradle.plugins.signing.SigningExtension
 
 const val RULER_PLUGIN_GROUP = "com.spotify.ruler"
-const val RULER_PLUGIN_VERSION = "2.0.0-beta-2" // Also adapt this version in the README
+const val RULER_PLUGIN_VERSION = "2.0.0-beta-3" // Also adapt this version in the README
 const val EXT_POM_NAME = "POM_NAME"
 const val EXT_POM_DESCRIPTION = "POM_DESCRIPTION"
 

--- a/ruler-common/build.gradle.kts
+++ b/ruler-common/build.gradle.kts
@@ -44,11 +44,11 @@ dependencies {
     compileOnly(Dependencies.ANDROID_GRADLE_PLUGIN)
     testRuntimeOnly(Dependencies.ANDROID_GRADLE_PLUGIN)
 
-    compileOnly(Dependencies.BUNDLETOOL)
-    compileOnly(Dependencies.PROTOBUF_CORE)
-    compileOnly(Dependencies.ANDROID_TOOLS_COMMON)
-    compileOnly(Dependencies.ANDROID_TOOLS_SDKLIB)
-    compileOnly(Dependencies.DEXLIB)
+    implementation(Dependencies.BUNDLETOOL)
+    implementation(Dependencies.PROTOBUF_CORE)
+    implementation(Dependencies.ANDROID_TOOLS_COMMON)
+    implementation(Dependencies.ANDROID_TOOLS_SDKLIB)
+    implementation(Dependencies.DEXLIB)
 
     implementation(project(":ruler-models"))
 

--- a/ruler-common/src/test/kotlin/com/spotify/ruler/common/apk/ApkParserTest.kt
+++ b/ruler-common/src/test/kotlin/com/spotify/ruler/common/apk/ApkParserTest.kt
@@ -38,6 +38,6 @@ class ApkParserTest {
         val entries = parser.parse(apkFile)
         val dex = entries.filterIsInstance<ApkEntry.Dex>().single()
 
-        assertThat(dex.classes).contains(ApkEntry.Default("Lcom/spotify/ruler/sample/MainActivity;", 154, 154))
+        assertThat(dex.classes).contains(ApkEntry.Default("Lcom/spotify/ruler/sample/MainActivity;", 124, 124))
     }
 }


### PR DESCRIPTION
After the Gradle bump, we are getting:`
Exception in thread "main" java.lang.NoClassDefFoundError: com/android/bundle/Commands$BuildApksResult` this ensures things are compiled and the class are available