### PR TITLE
Support configuration cache feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ ruler {
 
 ### Running the task
 
-Once this is done, `analyze<VariantName>Bundle` tasks will be added for each of your app variants. Running this task will build the app and generate a HTML report, which you can use to analyze your app size. It will also generate a JSON report, in case you want to further process the data.
+Once this is done, `analyze<VariantName>Bundle` tasks will be added for each of your app variants. Running this task will build the app and generate an HTML report, which you can use to analyze your app size. It will also generate a JSON report, in case you want to further process the data.
 
 ## Ownership
 
@@ -133,7 +133,7 @@ The project is set up like a standard Gradle project. You can build it using `./
 
 There is also a sample project, which shows the usage of the plugin. Because the way this sample project is set up, the initial build can fail if you bump the plugin version. To fix this, you have to publish the plugin to your local Maven repository by running `./gradlew publishToMavenLocal -PwithoutSample`.
 
-When working on the frontend, you can start a development server by running `./gradlew browserRun`, which will show a report filled with dummy data to make development easier.
+When working on the frontend, you can start a development server by running `./gradlew jsBrowserRun`, which will show a report filled with dummy data to make development easier.
 
 ## Compatibility
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -18,5 +18,6 @@ org.gradle.jvmargs=-Xmx4608m -Dfile.encoding=UTF-8
 
 kotlin.code.style=official
 kotlin.mpp.stability.nowarn=true
+
 android.useAndroidX=true
 android.experimental.legacyTransform.forceNonIncremental=true

--- a/ruler-common/src/main/java/com/spotify/ruler/common/dependency/DependencyEntry.kt
+++ b/ruler-common/src/main/java/com/spotify/ruler/common/dependency/DependencyEntry.kt
@@ -16,20 +16,30 @@
 
 package com.spotify.ruler.common.dependency
 
+import java.io.Serializable
+import kotlinx.serialization.Serializable as KSerializable
+
 /** Single entry of a dependency. */
-sealed class DependencyEntry {
+@KSerializable
+sealed class DependencyEntry: Serializable {
     abstract val name: String
     abstract val component: String
 
     /** Default dependency entry. If an entry has no special type, it is considered to be a default entry. */
+    @KSerializable
     data class Default(
         override val name: String,
         override val component: String,
     ) : DependencyEntry()
 
     /** Class file dependency entry. */
+    @KSerializable
     data class Class(
         override val name: String,
         override val component: String,
     ) : DependencyEntry()
+
+    companion object {
+        private const val serialVersionUID = 1L
+    }
 }

--- a/ruler-frontend/build.gradle.kts
+++ b/ruler-frontend/build.gradle.kts
@@ -22,7 +22,7 @@ plugins {
 kotlin {
     js(IR) {
         browser {
-            commonWebpackConfig (Action {
+            commonWebpackConfig(Action {
                 cssSupport {
                     enabled.set(true)
                 }

--- a/ruler-gradle-plugin/src/main/kotlin/com/spotify/ruler/plugin/FileProvider.kt
+++ b/ruler-gradle-plugin/src/main/kotlin/com/spotify/ruler/plugin/FileProvider.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.spotify.ruler.plugin
 
 import com.android.build.api.artifact.SingleArtifact
@@ -63,7 +78,7 @@ internal fun Project.getResourceMappingFile(
     variant: ApplicationVariant
 ): Provider<RegularFile> {
     val defaultResourceMappingFile = project.objects.fileProperty() // Empty by default
-    @Suppress("SpellCheckingInspection")
+
     val resourceMappingFilePath = when {
         hasDexGuard(project) -> "outputs/dexguard/mapping/bundle/${variant.name}/resourcefilenamemapping.txt"
         else -> return defaultResourceMappingFile // No DexGuard plugin -> use default empty file
@@ -88,6 +103,5 @@ private fun hasDexGuard(project: Project): Boolean {
 
 /** Checks if the given [project] is using ProGuard for obfuscation, instead of R8. */
 private fun hasProGuard(project: Project): Boolean {
-    @Suppress("SpellCheckingInspection")
     return project.pluginManager.hasPlugin("com.guardsquare.proguard")
 }

--- a/ruler-gradle-plugin/src/main/kotlin/com/spotify/ruler/plugin/FileProvider.kt
+++ b/ruler-gradle-plugin/src/main/kotlin/com/spotify/ruler/plugin/FileProvider.kt
@@ -1,0 +1,93 @@
+package com.spotify.ruler.plugin
+
+import com.android.build.api.artifact.SingleArtifact
+import com.android.build.api.variant.ApplicationVariant
+import org.gradle.api.Project
+import org.gradle.api.file.RegularFile
+import org.gradle.api.provider.Provider
+
+/**
+ * Returns the bundle file that's going to be analyzed. DexGuard produces a separate bundle instead of overriding
+ * the default one, so we have to handle that separately.
+ */
+internal fun Project.getBundleFile(
+    variant: ApplicationVariant
+): Provider<RegularFile> {
+    val defaultBundleFile = variant.artifacts.get(SingleArtifact.BUNDLE)
+    if (!hasDexGuard(project)) {
+        return defaultBundleFile // No DexGuard means we can use the default bundle
+    }
+
+    // Bundle can still be in the default location, depending on the DexGuard config
+    return defaultBundleFile.flatMap { bundle ->
+        val dexGuardBundle =
+            bundle.asFile.parentFile.resolve("${bundle.asFile.nameWithoutExtension}-protected.aab")
+        if (dexGuardBundle.exists()) {
+            project.layout.buildDirectory.file(dexGuardBundle.absolutePath) // File exists -> use it
+        } else {
+            defaultBundleFile // File doesn't exist -> fall back to default
+        }
+    }
+}
+
+/**
+ * Returns the mapping file used for de-obfuscation. Different obfuscation tools like DexGuard and ProGuard place
+ * their mapping files in different directories, so we have to handle those separately.
+ */
+internal fun Project.getMappingFile(
+    variant: ApplicationVariant
+): Provider<RegularFile> {
+    val defaultMappingFile = variant.artifacts.get(SingleArtifact.OBFUSCATION_MAPPING_FILE)
+    val mappingFilePath = when {
+        hasDexGuard(project) -> "outputs/dexguard/mapping/bundle/${variant.name}/mapping.txt"
+        hasProGuard(project) -> "outputs/proguard/${variant.name}/mapping/mapping.txt"
+        else -> return defaultMappingFile // No special obfuscation plugin -> use default path
+    }
+
+    // Mapping files can also be missing, for example when obfuscation is disabled for a variant
+    val mappingFileProvider = project.layout.buildDirectory.file(mappingFilePath)
+    return mappingFileProvider.flatMap { mappingFile ->
+        if (mappingFile.asFile.exists()) {
+            mappingFileProvider // File exists -> use it
+        } else {
+            defaultMappingFile // File doesn't exist -> fall back to default
+        }
+    }
+}
+
+/**
+ * Returns a mapping file to de-obfuscate resource names. DexGuard supports this feature by default, so we need to
+ * handle it accordingly.
+ */
+internal fun Project.getResourceMappingFile(
+    variant: ApplicationVariant
+): Provider<RegularFile> {
+    val defaultResourceMappingFile = project.objects.fileProperty() // Empty by default
+    @Suppress("SpellCheckingInspection")
+    val resourceMappingFilePath = when {
+        hasDexGuard(project) -> "outputs/dexguard/mapping/bundle/${variant.name}/resourcefilenamemapping.txt"
+        else -> return defaultResourceMappingFile // No DexGuard plugin -> use default empty file
+    }
+
+    // Mapping file can still be missing, for example if resource obfuscation is disabled for a variant
+    val resourceMappingFileProvider =
+        project.layout.buildDirectory.file(resourceMappingFilePath)
+    return resourceMappingFileProvider.flatMap { resourceMappingFile ->
+        if (resourceMappingFile.asFile.exists()) {
+            resourceMappingFileProvider // File exists -> use it
+        } else {
+            defaultResourceMappingFile // File doesn't exist -> fall back to default
+        }
+    }
+}
+
+/** Checks if the given [project] is using DexGuard for obfuscation, instead of R8. */
+private fun hasDexGuard(project: Project): Boolean {
+    return project.pluginManager.hasPlugin("dexguard")
+}
+
+/** Checks if the given [project] is using ProGuard for obfuscation, instead of R8. */
+private fun hasProGuard(project: Project): Boolean {
+    @Suppress("SpellCheckingInspection")
+    return project.pluginManager.hasPlugin("com.guardsquare.proguard")
+}

--- a/ruler-gradle-plugin/src/main/kotlin/com/spotify/ruler/plugin/RulerPlugin.kt
+++ b/ruler-gradle-plugin/src/main/kotlin/com/spotify/ruler/plugin/RulerPlugin.kt
@@ -21,6 +21,7 @@ import com.android.build.api.variant.ApplicationVariant
 import com.spotify.ruler.common.models.AppInfo
 import com.spotify.ruler.common.models.DeviceSpec
 import com.spotify.ruler.common.veritication.VerificationConfig
+import com.spotify.ruler.plugin.dependency.EntryParser
 import org.codehaus.groovy.runtime.StringGroovyMethods
 import org.gradle.api.Plugin
 import org.gradle.api.Project
@@ -47,6 +48,14 @@ class RulerPlugin : Plugin<Project> {
                     RulerTask::class.java
                 ) { task ->
                     task.group = name
+
+                    val resolve = EntryParser().parse(variant.runtimeConfiguration)
+
+                    resolve.forEach(task.dependencyEntries::put)
+
+                    task.projectPath.set(project.path)
+                    task.sdkDirectory.set(androidComponents.sdkComponents.sdkDirectory)
+
                     task.appInfo.set(getAppInfo(project, variant))
                     task.deviceSpec.set(getDeviceSpec(rulerExtension))
 

--- a/ruler-gradle-plugin/src/main/kotlin/com/spotify/ruler/plugin/RulerTask.kt
+++ b/ruler-gradle-plugin/src/main/kotlin/com/spotify/ruler/plugin/RulerTask.kt
@@ -16,32 +16,51 @@
 
 package com.spotify.ruler.plugin
 
-import com.android.build.gradle.BaseExtension
 import com.spotify.ruler.common.BaseRulerTask
 import com.spotify.ruler.common.apk.ApkCreator
 import com.spotify.ruler.common.dependency.DependencyComponent
+import com.spotify.ruler.common.dependency.DependencyEntry
 import com.spotify.ruler.common.dependency.DependencySanitizer
 import com.spotify.ruler.common.models.AppInfo
 import com.spotify.ruler.common.models.DeviceSpec
 import com.spotify.ruler.common.models.RulerConfig
 import com.spotify.ruler.common.sanitizer.ClassNameSanitizer
 import com.spotify.ruler.common.veritication.VerificationConfig
-import com.spotify.ruler.plugin.dependency.EntryParser
 import org.gradle.api.DefaultTask
 import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.file.RegularFile
 import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.provider.ListProperty
+import org.gradle.api.provider.MapProperty
 import org.gradle.api.provider.Property
+import org.gradle.api.tasks.CacheableTask
 import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.InputDirectory
 import org.gradle.api.tasks.InputFile
 import org.gradle.api.tasks.InputFiles
+import org.gradle.api.tasks.PathSensitive
+import org.gradle.api.tasks.PathSensitivity
 import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.OutputDirectory
 import org.gradle.api.tasks.TaskAction
+import org.gradle.workers.WorkAction
+import org.gradle.workers.WorkParameters
+import org.gradle.workers.WorkerExecutor
 import java.io.File
+import javax.inject.Inject
 
-abstract class RulerTask : DefaultTask(), BaseRulerTask {
+@CacheableTask
+abstract class RulerTask : DefaultTask() {
+
+    @get:Input
+    abstract val dependencyEntries: MapProperty<String, List<DependencyEntry>>
+
+    @get:Input
+    abstract val projectPath: Property<String>
+
+    @get:InputDirectory
+    @get:PathSensitive(PathSensitivity.RELATIVE)
+    abstract val sdkDirectory: DirectoryProperty
 
     @get:Input
     abstract val appInfo: Property<AppInfo>
@@ -50,18 +69,22 @@ abstract class RulerTask : DefaultTask(), BaseRulerTask {
     abstract val deviceSpec: Property<DeviceSpec>
 
     @get:InputFile
+    @get:PathSensitive(PathSensitivity.NONE)
     abstract val bundleFile: RegularFileProperty
 
     @get:Optional
     @get:InputFile
+    @get:PathSensitive(PathSensitivity.RELATIVE)
     abstract val mappingFile: RegularFileProperty
 
     @get:Optional
     @get:InputFile
+    @get:PathSensitive(PathSensitivity.RELATIVE)
     abstract val resourceMappingFile: RegularFileProperty
 
     @get:Optional
     @get:InputFile
+    @get:PathSensitive(PathSensitivity.RELATIVE)
     abstract val ownershipFile: RegularFileProperty
 
     @get:Input
@@ -72,10 +95,12 @@ abstract class RulerTask : DefaultTask(), BaseRulerTask {
 
     @get:Optional
     @get:InputFiles
+    @get:PathSensitive(PathSensitivity.RELATIVE)
     abstract val unstrippedNativeFiles: ListProperty<RegularFile>
 
     @get:Optional
     @get:InputFile
+    @get:PathSensitive(PathSensitivity.RELATIVE)
     abstract val staticDependenciesFile: RegularFileProperty
 
     @get:Input
@@ -87,61 +112,103 @@ abstract class RulerTask : DefaultTask(), BaseRulerTask {
     @get:OutputDirectory
     abstract val reportDir: DirectoryProperty
 
+    @get:Inject
+    abstract val workerExecutor: WorkerExecutor
+
     @TaskAction
     fun analyze() {
-        run()
+        workerExecutor.noIsolation().submit(RulerTaskAction::class.java) {
+            it.dependencyEntries.set(dependencyEntries)
+            it.projectPath.set(projectPath)
+            it.sdkDirectory.set(sdkDirectory)
+            it.appInfo.set(appInfo)
+            it.deviceSpec.set(deviceSpec)
+            it.bundleFile.set(bundleFile)
+            it.mappingFile.set(mappingFile)
+            it.resourceMappingFile.set(resourceMappingFile)
+            it.ownershipFile.set(ownershipFile)
+            it.defaultOwner.set(defaultOwner)
+            it.omitFileBreakdown.set(omitFileBreakdown)
+            it.unstrippedNativeFiles.set(unstrippedNativeFiles)
+            it.staticDependenciesFile.set(staticDependenciesFile)
+            it.verificationConfig.set(verificationConfig)
+            it.workingDir.set(workingDir)
+            it.reportDir.set(reportDir)
+        }
     }
 
-    private val config by lazy {
-        RulerConfig(
-            projectPath = project.path,
-            apkFilesMap = createApkFile(),
-            reportDir = reportDir.asFile.get(),
-            ownershipFile = ownershipFile.asFile.orNull,
-            staticDependenciesFile = staticDependenciesFile.asFile.orNull,
-            appInfo = appInfo.get(),
-            deviceSpec = deviceSpec.get(),
-            defaultOwner = defaultOwner.get(),
-            omitFileBreakdown = omitFileBreakdown.get(),
-            additionalEntries = emptyList(),
-            ignoredFiles = emptyList(),
-            verificationConfig = verificationConfig.get()
-        )
+    abstract class Params : WorkParameters {
+        abstract val dependencyEntries: MapProperty<String, List<DependencyEntry>>
+        abstract val projectPath: Property<String>
+        abstract val sdkDirectory: DirectoryProperty
+        abstract val appInfo: Property<AppInfo>
+        abstract val deviceSpec: Property<DeviceSpec>
+        abstract val bundleFile: RegularFileProperty
+        abstract val mappingFile: RegularFileProperty
+        abstract val resourceMappingFile: RegularFileProperty
+        abstract val ownershipFile: RegularFileProperty
+        abstract val defaultOwner: Property<String>
+        abstract val omitFileBreakdown: Property<Boolean>
+        abstract val unstrippedNativeFiles: ListProperty<RegularFile>
+        abstract val staticDependenciesFile: RegularFileProperty
+        abstract val verificationConfig: Property<VerificationConfig>
+        abstract val workingDir: DirectoryProperty
+        abstract val reportDir: DirectoryProperty
     }
 
-    override fun rulerConfig(): RulerConfig = config
+    abstract class RulerTaskAction : WorkAction<Params>, BaseRulerTask {
 
-    override fun provideDependencies(): Map<String, List<DependencyComponent>> {
-        val dependencyParser = EntryParser()
-        val entries = dependencyParser.parse(project, rulerConfig().appInfo)
+        override fun execute() {
+            run()
+        }
 
-        val classNameSanitizer = ClassNameSanitizer(provideMappingFile())
-        val dependencySanitizer = DependencySanitizer(classNameSanitizer)
-        return dependencySanitizer.sanitize(entries)
-    }
-
-    override fun print(content: String) = project.logger.lifecycle(content)
-    override fun provideMappingFile(): File? = mappingFile.asFile.orNull
-    override fun provideResourceMappingFile(): File? = resourceMappingFile.asFile.orNull
-    override fun provideUnstrippedLibraryFiles(): List<File> = unstrippedNativeFiles.get().map {
-        it.asFile
-    }
-
-    override fun provideBloatyPath() = null
-
-    private fun createApkFile(): Map<String, List<File>> {
-        val android = project.extensions.findByName("android") as BaseExtension?
-        val apkCreator = ApkCreator(android?.sdkDirectory)
-
-        val apkFile = bundleFile.asFile.get()
-        return if (apkFile.extension == "apk") {
-            mapOf(ApkCreator.BASE_FEATURE_NAME to listOf(apkFile))
-        } else {
-            apkCreator.createSplitApks(
-                apkFile,
-                deviceSpec.get(),
-                workingDir.asFile.get()
+        private val config by lazy {
+            RulerConfig(
+                projectPath = parameters.projectPath.get(),
+                apkFilesMap = createApkFile(),
+                reportDir = parameters.reportDir.asFile.get(),
+                ownershipFile = parameters.ownershipFile.asFile.orNull,
+                staticDependenciesFile = parameters.staticDependenciesFile.asFile.orNull,
+                appInfo = parameters.appInfo.get(),
+                deviceSpec = parameters.deviceSpec.get(),
+                defaultOwner = parameters.defaultOwner.get(),
+                omitFileBreakdown = parameters.omitFileBreakdown.get(),
+                additionalEntries = emptyList(),
+                ignoredFiles = emptyList(),
+                verificationConfig = parameters.verificationConfig.get(),
             )
+        }
+
+        override fun rulerConfig(): RulerConfig = config
+
+        override fun provideDependencies(): Map<String, List<DependencyComponent>> {
+            val classNameSanitizer = ClassNameSanitizer(provideMappingFile())
+            val dependencySanitizer = DependencySanitizer(classNameSanitizer)
+            return dependencySanitizer.sanitize(parameters.dependencyEntries.get().values.flatten())
+        }
+
+        override fun print(content: String) = println(content) // Use println directly?
+        override fun provideMappingFile(): File? = parameters.mappingFile.asFile.orNull
+        override fun provideResourceMappingFile(): File? = parameters.resourceMappingFile.asFile.orNull
+        override fun provideUnstrippedLibraryFiles(): List<File> = parameters.unstrippedNativeFiles.get().map {
+            it.asFile
+        }
+
+        override fun provideBloatyPath() = null
+
+        private fun createApkFile(): Map<String, List<File>> {
+            val apkCreator = ApkCreator(parameters.sdkDirectory.asFile.get())
+
+            val apkFile = parameters.bundleFile.asFile.get()
+            return if (apkFile.extension == "apk") {
+                mapOf(ApkCreator.BASE_FEATURE_NAME to listOf(apkFile))
+            } else {
+                apkCreator.createSplitApks(
+                    apkFile,
+                    parameters.deviceSpec.get(),
+                    parameters.workingDir.asFile.get(),
+                )
+            }
         }
     }
 }

--- a/ruler-gradle-plugin/src/main/kotlin/com/spotify/ruler/plugin/dependency/EntryParser.kt
+++ b/ruler-gradle-plugin/src/main/kotlin/com/spotify/ruler/plugin/dependency/EntryParser.kt
@@ -19,31 +19,23 @@ package com.spotify.ruler.plugin.dependency
 import com.spotify.ruler.common.dependency.ArtifactResult
 import com.spotify.ruler.common.dependency.DependencyEntry
 import com.spotify.ruler.common.dependency.DependencyParser
-import com.spotify.ruler.common.models.AppInfo
-import org.gradle.api.Project
+import org.gradle.api.Transformer
 import org.gradle.api.artifacts.Configuration
 import org.gradle.api.artifacts.result.ResolvedArtifactResult
 import org.gradle.api.attributes.Attribute
+import org.gradle.api.provider.Provider
 import java.io.File
 
 /** Responsible for parsing and extracting entries from dependencies. */
 class EntryParser {
 
-    /** Parses and returns the list of entries contained in all dependencies of the given [project]. */
-    fun parse(project: Project, appInfo: AppInfo): List<DependencyEntry> {
-        val configuration =
-            project.configurations.getByName("${appInfo.variantName}RuntimeClasspath")
-        val entries = mutableListOf<ArtifactResult>()
-        val parser = DependencyParser()
-        listOf("android-classes").forEach { artifactType ->
-            entries += parseFile(configuration, artifactType, true)
+    /** Parses and returns the list of entries contained in all dependencies of the given [configuration]. */
+    fun parse(configuration: Configuration): Map<String, Provider<List<DependencyEntry>>> {
+        return listOf("android-classes").associateWith { artifactType ->
+            parseFile(configuration, artifactType, true)
+        } + listOf("android-res", "android-assets", "android-jni").associateWith { artifactType ->
+            parseFile(configuration, artifactType, false)
         }
-
-        listOf("android-res", "android-assets", "android-jni").forEach { artifactType ->
-            entries += parseFile(configuration, artifactType, false)
-        }
-
-        return parser.parse(entries)
     }
 
     private fun getArtifactView(
@@ -56,32 +48,54 @@ class EntryParser {
                 artifactType
             )
         }
-    }.artifacts.artifacts
+    }.artifacts.resolvedArtifacts
 
     private fun parseFile(
         configuration: Configuration,
         artifactType: String,
-        isJarOrClass: Boolean
-    ) = getArtifactView(configuration, artifactType).flatMap { artifactResult ->
-        val artifactFiles = artifactResult.file.walkTopDown().filter(File::isFile)
-        val component = getComponentIdentifier(artifactResult)
-        if (isJarOrClass) {
-            artifactFiles.map { artifactFile ->
-                when (artifactFile.extension.lowercase()) {
-                    "jar" -> ArtifactResult.JarArtifact(artifactFile, component)
-                    "class" -> ArtifactResult.ClassArtifact(artifactFile, artifactResult.file, component)
-                    // in case there are files we don't recognize on the classpath, fallback to a default artifact
-                    else -> ArtifactResult.DefaultArtifact(artifactFile, artifactResult.file, component)
+        isJarOrClass: Boolean,
+    ) = getArtifactView(configuration, artifactType).map { artifactResult ->
+        DependencyEntryExtractor(isJarOrClass).transform(artifactResult)
+    }
+
+    internal class DependencyEntryExtractor(private val isJarOrClass: Boolean) :
+        Transformer<List<DependencyEntry>, Collection<ResolvedArtifactResult>> {
+
+        private val parser = DependencyParser()
+
+        override fun transform(artifacts: Collection<ResolvedArtifactResult>): List<DependencyEntry> {
+            return artifacts.flatMap { artifactResult ->
+                val artifactFiles = artifactResult.file.walkTopDown().filter(File::isFile)
+                val component = getComponentIdentifier(artifactResult)
+                if (isJarOrClass) {
+                    artifactFiles.map { artifactFile ->
+                        when (artifactFile.extension.lowercase()) {
+                            "jar" -> ArtifactResult.JarArtifact(artifactFile, component)
+                            "class" -> ArtifactResult.ClassArtifact(
+                                artifactFile,
+                                artifactResult.file,
+                                component,
+                            )
+                            // in case there are files we don't recognize on the classpath,
+                            // fallback to a default artifact
+                            else -> ArtifactResult.DefaultArtifact(
+                                artifactFile,
+                                artifactResult.file,
+                                component,
+                            )
+                        }
+                    }
+                } else {
+                    artifactFiles.map { artifactFile ->
+                        ArtifactResult.DefaultArtifact(artifactFile, artifactResult.file, component)
+                    }
                 }
-            }
-        } else {
-            artifactFiles.map { artifactFile ->
-                ArtifactResult.DefaultArtifact(artifactFile, artifactResult.file, component)
-            }
+            }.run(parser::parse)
+        }
+
+        private fun getComponentIdentifier(artifactResult: ResolvedArtifactResult): String {
+            return artifactResult.id.componentIdentifier.displayName
         }
     }
 
-    private fun getComponentIdentifier(artifactResult: ResolvedArtifactResult): String {
-        return artifactResult.id.componentIdentifier.displayName
-    }
 }

--- a/sample/lib/src/main/res/layout/activity_lib.xml
+++ b/sample/lib/src/main/res/layout/activity_lib.xml
@@ -21,7 +21,7 @@
     android:layout_height="match_parent"
     android:paddingVertical="18dp"
     android:paddingHorizontal="12dp"
-    tools:context=".MainActivity">
+    tools:context=".LibActivity">
 
     <TextView
         android:layout_width="wrap_content"


### PR DESCRIPTION
### What has changed
<!-- A concise description of the changes contained in this pull request. -->
![Snipaste_2025-01-08_20-07-00](https://github.com/user-attachments/assets/b6faeec3-cf46-453f-8250-9aca0c553510)
- Configuration cache feature supported
- Extract the file method to the `FileProvider.kt`

### Why was it changed
<!-- A concise description of why these changes are being proposed. -->
Configuration cache is not currently supported for the following reasons:
- use `project` in executing time.
 ```
 override fun provideDependencies(): Map<String, List<DependencyComponent>> {
        val dependencyParser = EntryParser()
        val entries = dependencyParser.parse(project, rulerConfig().appInfo)

        val classNameSanitizer = ClassNameSanitizer(provideMappingFile())
        val dependencySanitizer = DependencySanitizer(classNameSanitizer)
        return dependencySanitizer.sanitize(entries)
 }

override fun print(content: String) = project.logger.lifecycle(content)
 ```
- exec operations in executing time
```
private fun createApkFile(): Map<String, List<File>> {
        val android = project.extensions.findByName("android") as BaseExtension?
        val apkCreator = ApkCreator(android?.sdkDirectory)

        val apkFile = bundleFile.asFile.get()
        return if (apkFile.extension == "apk") {
            mapOf(ApkCreator.BASE_FEATURE_NAME to listOf(apkFile))
        } else {
            apkCreator.createSplitApks(
                apkFile,
                deviceSpec.get(),
                workingDir.asFile.get()
            )
        }
    }
```

### Related issues
<!-- Links to any related issues, if there are some. -->
https://github.com/spotify/ruler/issues/140

